### PR TITLE
MAPEX-159: Fix Date Export

### DIFF
--- a/src/mappings_editor/src/assets/configuration/app.config.serializer.ts
+++ b/src/mappings_editor/src/assets/configuration/app.config.serializer.ts
@@ -38,8 +38,8 @@ export class UniversalSchemaMappingFileSerializer extends MappingFileSerializer 
                 author                    : file.author,
                 contact                   : file.author_contact,
                 organization              : file.author_organization,
-                creation_date             : file.creation_date.toString(),
-                last_update               : file.modified_date.toString(),
+                creation_date             : file.creation_date.toLocaleDateString("en-US"),
+                last_update               : file.modified_date.toLocaleDateString("en-US"),
                 mapping_types             : file.mapping_types,
                 groups                    : file.mapping_groups
             },


### PR DESCRIPTION
Fixes #159

## What Changed
This PR switches the Mapping Editor's date export from the standard ISO format to `MM/DD/YYYY` (per the schema).

## Known Limitations
None