### PR TITLE
MAPEX-177: Fix Mapping Object Camera Tracking

### DIFF
--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/index.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/index.ts
@@ -392,7 +392,7 @@ export function setMappingObjectViewProperty(view: MappingObjectView, command: E
                 new ReindexMappingObjects(view.id),
                 new RebuildViewBreakouts(view.fileView),
                 new SelectMappingObjectViews(view, undefined, true, true),
-                new MoveCameraToViewItem(view, undefined, camera, camera)
+                new MoveCameraToViewItem(view, camera, camera)
             ];
         }
     )


### PR DESCRIPTION
Fixes #177

## What Changed
This PR addresses a bug that keeps the camera from tracking Mapping Objects when they're modified.

## Known Limitations
None