### PR TITLE
MAPEX-176: Visually Identify Invalid Mapping Object Fields

### DIFF
--- a/src/mappings_editor/src/components/Controls/Fields/DynamicFrameworkObjectField.vue
+++ b/src/mappings_editor/src/components/Controls/Fields/DynamicFrameworkObjectField.vue
@@ -13,9 +13,10 @@
     />
     <div :class="['value', {
       'is-null': isNull,
+      'is-cached': isCached,
       'is-targeted': property.isTargeted,
-      'options-open': showOptions }]"
-    >
+      'options-open': showOptions
+    }]">
       <input 
         ref="objectIdField"
         type="text"
@@ -32,20 +33,22 @@
         autocomplete="off"
       />
       <span></span>
-      <input 
-        type="text"
-        name="object-text"
-        class="object-text"
-        @input="onObjectTextInput"
-        @keyup.stop
-        @keydown.stop
-        @focusin="onObjectTextFocusIn"
-        @focusout="onObjectTextFocusOut"
-        v-model="objectText"
-        :disabled="isObjectTextFieldDisabled"
-        :placeholder="objectTextPlaceholder"
-        autocomplete="off"
-      />
+      <div class="object-text-container">
+        <input 
+          type="text"
+          name="object-text"
+          class="object-text"
+          @input="onObjectTextInput"
+          @keyup.stop
+          @keydown.stop
+          @focusin="onObjectTextFocusIn"
+          @focusout="onObjectTextFocusOut"
+          v-model="objectText"
+          :disabled="isObjectTextFieldDisabled"
+          :placeholder="objectTextPlaceholder"
+          autocomplete="off"
+        />
+      </div>
     </div>
   </div>
 </template>
@@ -100,6 +103,15 @@ export default defineComponent({
      */
     isNull(): boolean {
       return this.property.objectId === null;
+    },
+
+    /**
+     * Tests if the option's value is cached.
+     * @returns
+     *  True if the option's value is cached, false otherwise.
+     */
+    isCached(): boolean {
+      return this.property.isObjectValueCached();
     },
     
     /**
@@ -428,10 +440,19 @@ export default defineComponent({
   background: #637bc9;
 }
 
-.value .object-text {
+.value .object-text-container {
   flex: 1;
   display: flex;
   align-items: center;
+  height: 100%;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
+  box-sizing: border-box;
+  background: #404040;
+}
+
+.value .object-text {
+  flex: 1;
   color: inherit;
   font-family: inherit;
   font-size: inherit;
@@ -442,15 +463,7 @@ export default defineComponent({
   border-top-right-radius: 3px;
   border-bottom-right-radius: 3px;
   box-sizing: border-box;
-  background: #404040;
-  overflow: hidden;
-}
-
-.value .object-id p,
-.value .object-text p {
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
+  background: none;
 }
 
 .value .object-id::placeholder,
@@ -466,11 +479,11 @@ export default defineComponent({
   border-top-left-radius: 0px;
 }
 
-.options-list:not(.flip) + .value.options-open .object-text {
+.options-list:not(.flip) + .value.options-open .object-text-container {
   border-bottom-right-radius: 0px;
 }
 
-.options-list.flip + .value.options-open .object-text {
+.options-list.flip + .value.options-open .object-text-container {
   border-top-right-radius: 0px;
 }
 
@@ -484,16 +497,37 @@ export default defineComponent({
   background: #404040;
 }
 
-.value.is-null .object-text {
+.value.is-null .object-text-container {
   user-select: none;
   pointer-events: none;
 }
 
-.value .object-text:disabled {
+/** === Invalid Value Text === */
+
+.value.is-cached .object-id {
+  color: #cccccc;
+  background: #404040;
+}
+
+.value.is-cached .object-text-container::after {
+  content: "⚠";
+  color: #adadad;
+  font-size: 10.5pt;
+  margin-right: 9px;
+}
+
+/** === Disabled Value Text === */
+
+.value.is-null .object-text-container,
+.value.is-cached .object-text-container  {
   color: #a8a8a8;
-  padding: 0px 10px 0px 14px;
   border: solid 1px #404040;
   background: #303030;
+}
+
+.value.is-null .object-text,
+.value.is-cached .object-text {
+  padding: 0px 14px;
 }
 
 /** === Focused Value Text === */

--- a/src/mappings_editor/src/components/Controls/Fields/ListItemField.vue
+++ b/src/mappings_editor/src/components/Controls/Fields/ListItemField.vue
@@ -10,7 +10,7 @@
       @select="updateProperty"
       v-if="showMenu"
     />
-    <div :class="['value-container', { 'search-open': showSearch }]">
+    <div :class="['value-container', { 'search-open': showSearch, 'is-cached': isCached }]">
       <div :class="['value-text', { 'is-null': isNull }]">
         {{ property.exportText ?? placeholder }}
       </div>
@@ -27,6 +27,7 @@
         v-if="showSearch"
         autocomplete="off"
       />
+      <div class="invalid-icon">⚠</div>
       <div class="dropdown-arrow">▼</div>
     </div>
   </div>
@@ -75,6 +76,15 @@ export default defineComponent({
      */
     isNull(): boolean {
       return this.property.value === null;
+    },
+
+    /**
+     * Tests if the option's value is cached.
+     * @returns
+     *  True if the option's value is cached, false otherwise.
+     */
+    isCached(): boolean {
+      return this.property.isValueCached();
     },
     
     /**
@@ -347,6 +357,17 @@ export default defineComponent({
 
 .value-text.is-null {
   color: #999;
+}
+
+.invalid-icon {
+  display: none;
+  color: #adadad;
+  font-size: 10.5pt;
+  margin-right: 9px;
+}
+
+.value-container.is-cached .invalid-icon {
+  display: block;
 }
 
 .dropdown-arrow {

--- a/src/mappings_editor/src/components/Controls/Fields/StrictFrameworkObjectField.vue
+++ b/src/mappings_editor/src/components/Controls/Fields/StrictFrameworkObjectField.vue
@@ -11,7 +11,7 @@
       @select="updatePropertyObjectId"
       v-if="showMenu"
     />
-    <div :class="['value-container', { 'search-open': showSearch }]">
+    <div :class="['value-container', { 'search-open': showSearch, 'is-cached': isCached }]">
       <div :class="['value', { 'is-null': isNull }]">
         <div class="object-id" :style="objectIdStyle">
           <p>{{ property.objectId ?? idPlaceholder }}</p>
@@ -33,6 +33,7 @@
         v-if="showSearch"
         autocomplete="off"
       />
+      <div class="invalid-icon">⚠</div>
       <div class="dropdown-arrow">▼</div>
     </div>
   </div>
@@ -85,6 +86,15 @@ export default defineComponent({
      */
     isNull(): boolean {
       return this.property.objectId === null;
+    },
+
+    /**
+     * Tests if the option's value is cached.
+     * @returns
+     *  True if the option's value is cached, false otherwise.
+     */
+    isCached(): boolean {
+      return this.property.isObjectValueCached();
     },
     
     /**
@@ -350,7 +360,6 @@ export default defineComponent({
   text-overflow: ellipsis;
 }
 
-
 .value .object-text {
   flex: 1;
   white-space: nowrap;
@@ -372,6 +381,22 @@ export default defineComponent({
   font-size: inherit;
   font-weight: inherit;
   background: #404040;
+}
+
+.value-container.is-cached .object-id {
+  color: #cccccc;
+  background: #404040;
+}
+
+.invalid-icon {
+  display: none;
+  color: #adadad;
+  font-size: 10.5pt;
+  margin-right: 9px;
+}
+
+.value-container.is-cached .invalid-icon {
+  display: block;
 }
 
 .dropdown-arrow {


### PR DESCRIPTION
Fixes #176

## What Changed
Invalid Mapping Object fields are now visually distinguished from valid fields.

![image](https://github.com/center-for-threat-informed-defense/mappings-editor/assets/79934822/a274c07c-825d-4f7a-947c-2487d0d4011f)

## Known Limitations
None