### PR TITLE
MAPEX-181: Add Blank Mapping File

### DIFF
--- a/docs/blank_mappings_file.json
+++ b/docs/blank_mappings_file.json
@@ -1,0 +1,18 @@
+{
+  "metadata": {
+    "mapping_version": "1.0.0",
+    "attack_version": "",
+    "technology_domain": "",
+    "mapping_framework": "",
+    "mapping_framework_version": "",
+    "mapping_types": {
+      "example_type": {
+        "name": "Example Mapping Type",
+        "description": "Use this description to explain the semantics of the mapping type."
+      }
+    },
+    "capability_groups": {
+      "example_group": "Example Group"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #181

## What Changed
Adds a blank Mapping File to the repository so it can be linked from the Wiki.

## Known Limitations
None