### PR TITLE
MAPEX-190: Add User Guide to Help Menu

### DIFF
--- a/src/mappings_editor/src/assets/configuration/app.config.ts
+++ b/src/mappings_editor/src/assets/configuration/app.config.ts
@@ -16,6 +16,10 @@ const config: AppConfiguration = {
                 {
                     text: "Change Log",
                     url: "https://github.com/center-for-threat-informed-defense/mappings-editor/blob/main/src/mappings_editor/CHANGELOG.md"
+                },
+                {
+                    text: "User Guide",
+                    url: "https://github.com/center-for-threat-informed-defense/mappings-editor/wiki/Overview"
                 }
             ]
         }


### PR DESCRIPTION
Fixes #190

## What Changed
Adds a link to the Mappings Editor's User Guide to the Help Menu.

## Known Limitations
None