### PR TITLE
MAPEX-189: Open Files via URL

### DIFF
--- a/src/mappings_editor/src/App.vue
+++ b/src/mappings_editor/src/App.vue
@@ -201,6 +201,17 @@ export default defineComponent({
     }
     // Load settings
     this.application.execute(AppCommands.loadSettings(this.application, settings));
+    // Load file from query parameters, if possible
+    let params = new URLSearchParams(window.location.search);
+    let src = params.get("src");
+    if(src) {
+      try {
+        this.application.execute(await AppCommands.loadFileFromUrl(this.application, src));
+      } catch(ex) {
+        console.error(`Failed to load file from url: '${ src }'`);
+        console.error(ex);
+      }
+    }
   },
   mounted() {
     this.bodyWidth = this.body!.clientWidth;


### PR DESCRIPTION
Fixes #189

## What Changed
Adds a `src` query parameter that allows Mapping Files to be loaded by url.

## Known Limitations
None