### PR TITLE
MAPEX-210: Permit Asynchronous Execution of Application and Editor Commands

### DIFF
--- a/src/mappings_editor/src/App.vue
+++ b/src/mappings_editor/src/App.vue
@@ -35,7 +35,7 @@
 import * as AppCommands from "./assets/scripts/Application/Commands";
 // Dependencies
 import { PointerTracker } from "./assets/scripts/Utilities";
-import { useApplicationStore } from "./stores/ApplicationStore"; 
+import { useApplicationStore } from "./stores/ApplicationStore";
 import { defineComponent, markRaw, ref } from "vue";
 import { Browser, OperatingSystem, clamp } from "./assets/scripts/Utilities";
 import type { Command } from "./assets/scripts/Application";
@@ -131,9 +131,9 @@ export default defineComponent({
     async onExecute(cmd: Command) {
       try {
         if(cmd instanceof Promise) {
-          this.application.execute(await cmd);
+          await this.application.execute(await cmd);
         } else {
-          this.application.execute(cmd);
+          await this.application.execute(cmd);
         }
       } catch(ex: any) {
         alert(`Error: ${ ex.message }`)
@@ -175,13 +175,13 @@ export default defineComponent({
       const max = Math.max(min, this.bodyWidth - minRight - minCenter);
       this.activeFrameSize[Handle.Left] = clamp(size, min, max);
     },
-    
+
     /**
      * Sets the size of the right frame.
      * @param size
      *  The frame's new size.
      */
-    setRightFrameSize(size: number) { 
+    setRightFrameSize(size: number) {
       const minLeft = this.activeFrameSize[Handle.Left];
       const minCenter = this.minFrameSize[Handle.Center];
       const min = this.minFrameSize[Handle.Right];
@@ -200,13 +200,13 @@ export default defineComponent({
       settings = await (await fetch(`${ baseUrl }settings_win.json`)).json();
     }
     // Load settings
-    this.application.execute(AppCommands.loadSettings(this.application, settings));
+    await this.application.execute(AppCommands.loadSettings(this.application, settings));
     // Load file from query parameters, if possible
     let params = new URLSearchParams(window.location.search);
     let src = params.get("src");
     if(src) {
       try {
-        this.application.execute(await AppCommands.loadFileFromUrl(this.application, src));
+        await this.application.execute(await AppCommands.loadFileFromUrl(this.application, src));
       } catch(ex) {
         console.error(`Failed to load file from url: '${ src }'`);
         console.error(ex);

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/AppCommand.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/AppCommand.ts
@@ -11,6 +11,6 @@ export abstract class AppCommand  {
     /**
      * Executes the command.
      */
-    public abstract execute(): void;
+    public abstract execute(): Promise<void>;
 
 }

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/ApplicationSettings/LoadSettings.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/ApplicationSettings/LoadSettings.ts
@@ -32,8 +32,8 @@ export class LoadSettings extends AppCommand {
     /**
      * Executes the command.
      */
-    public execute(): void {
-        this._context.settings = this._settings; 
+    public async execute(): Promise<void> {
+        this._context.settings = this._settings;
     }
 
 }

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/FileManagement/ClearFileRecoveryBank.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/FileManagement/ClearFileRecoveryBank.ts
@@ -23,7 +23,7 @@ export class ClearFileRecoveryBank extends AppCommand {
     /**
      * Executes the command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         for(const id of this.context.fileRecoveryBank.files.keys()) {
             // Clear everything except the active file
             if(id === this.context.activeEditor.id) {

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/FileManagement/ImportFile.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/FileManagement/ImportFile.ts
@@ -40,7 +40,7 @@ export class ImportFile extends AppCommand {
         // Validate source framework
         if(file.sourceFramework !== importFile.source_framework) {
             throw new Error(
-                `The imported file's source framework ('${ 
+                `The imported file's source framework ('${
                     importFile.source_framework
                 }') doesn't match this file's source framework ('${
                     file.sourceFramework
@@ -50,7 +50,7 @@ export class ImportFile extends AppCommand {
         // Validate target framework
         if(file.targetFramework !== importFile.target_framework) {
             throw new Error(
-                `The imported file's target framework ('${ 
+                `The imported file's target framework ('${
                     importFile.target_framework
                 }') doesn't match this file's target framework ('${
                     file.targetFramework
@@ -64,7 +64,7 @@ export class ImportFile extends AppCommand {
     /**
      * Executes the command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         const file = this.editor.file;
         const view = this.editor.view;
         const convert = Reactivity.toRaw(this.fileAuthority.convertMappingObjectImportToParams);
@@ -93,7 +93,7 @@ export class ImportFile extends AppCommand {
             ]
         )
         // Execute insert
-        this.editor.execute(cmd);
+        await this.editor.execute(cmd);
         // Move first item into view
         const firstItem = view.getItems(o => objects.has(o.id)).next().value;
         view.moveToViewItem(firstItem.object.id, 0, true, false);
@@ -135,7 +135,7 @@ export class ImportFile extends AppCommand {
         const insertCmd = EditorCommands.createGroupCommand();
         for(const id in obj) {
             if(!prop.findListItemId(i => i.getAsString("id") === id)) {
-                const newItem = prop.createNewItem({ 
+                const newItem = prop.createNewItem({
                     id          : id,
                     name        : obj[id].name,
                     description : obj[id].description

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/FileManagement/LoadFile.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/FileManagement/LoadFile.ts
@@ -47,7 +47,7 @@ export class LoadFile extends AppCommand {
     /**
      * Executes the command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         this._context.activeEditor = this._editor;
     }
 

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/FileManagement/RemoveFileFromRecoveryBank.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/FileManagement/RemoveFileFromRecoveryBank.ts
@@ -32,7 +32,7 @@ export class RemoveFileFromRecoveryBank extends AppCommand {
     /**
      * Executes the command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         // Cancel any outstanding saves
         this.editor.tryCancelAutosave();
         // Remove file from recovery bank

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/FileManagement/SaveFileToDevice.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/FileManagement/SaveFileToDevice.ts
@@ -39,7 +39,7 @@ export class SaveFileToDevice extends AppCommand {
     /**
      * Executes the command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         Browser.downloadFile(
             this.name,
             this.contents,

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/FileManagement/SaveFileToRecoveryBank.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/FileManagement/SaveFileToRecoveryBank.ts
@@ -33,7 +33,7 @@ export class SaveFileToRecoveryBank extends AppCommand {
     /**
      * Executes the command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         // Create raw references
         const fileAuthority = toRaw(this.context.fileAuthority);
         const fileSerializer = toRaw(this.context.fileSerializer);

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/GroupCommand.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/GroupCommand.ts
@@ -15,7 +15,7 @@ export class GroupCommand extends AppCommand {
         super();
         this._commands = [];
     }
-    
+
 
     /**
      * Adds a command to the group.
@@ -29,9 +29,9 @@ export class GroupCommand extends AppCommand {
     /**
      * Applies the set of commands.
      */
-    public execute() {
+    public async execute(): Promise<void> {
         for(let i = 0; i < this._commands.length; i++) {
-            this._commands[i].execute();
+            await this._commands[i].execute();
         }
     }
 

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/MappingFileEditor/CopySelectedMappingObjects.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/MappingFileEditor/CopySelectedMappingObjects.ts
@@ -41,7 +41,7 @@ export class CopySelectedMappingObjects extends AppCommand {
     /**
      * Executes the command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         executeCopy(this.fileSerializer, this.fileAuthority, this.fileView);
     }
 

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/MappingFileEditor/CutSelectedMappingObjects.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/MappingFileEditor/CutSelectedMappingObjects.ts
@@ -50,11 +50,11 @@ export class CutSelectedMappingObjects extends AppCommand {
     /**
      * Executes the command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         // Copy selected objects
         const items = executeCopy(this.fileSerializer, this.fileAuthority, this.fileView);
         // Delete selected objects
-        this.editor.execute(EditorCommands.deleteMappingObjectViews(items));
+        await this.editor.execute(EditorCommands.deleteMappingObjectViews(items));
     }
 
 }

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/MappingFileEditor/PasteMappingObjects.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/MappingFileEditor/PasteMappingObjects.ts
@@ -42,10 +42,11 @@ export class PasteMappingObjects extends AppCommand {
     /**
      * Executes the command.
      */
-    public execute(): void {
-        navigator.clipboard.readText().then((text: string) => {
+    public async execute(): Promise<void> {
+        try {
+            const text = await navigator.clipboard.readText();
             const view = this.editor.view;
-            const rawFileSerializer = Reactivity.toRaw(this.fileSerializer); 
+            const rawFileSerializer = Reactivity.toRaw(this.fileSerializer);
             const convert = Reactivity.toRaw(this.fileAuthority.convertMappingObjectImportToParams);
             // Deserialize items
             const imports = rawFileSerializer.processPaste(text);
@@ -65,13 +66,13 @@ export class PasteMappingObjects extends AppCommand {
                 ]
             )
             // Execute insert
-            this.editor.execute(cmd);
+            await this.editor.execute(cmd);
             // Move first item into view
             const firstItem = view.getItems(o => objects.has(o.id)).next().value;
             view.moveToViewItem(firstItem.object.id, 0, true, false);
-        }).catch(reason => {
+        } catch(reason) {
             console.error("Failed to read clipboard: ", reason);
-        })
+        }
     }
 
 }

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/MappingFileEditor/RedoEditorCommand.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/MappingFileEditor/RedoEditorCommand.ts
@@ -23,8 +23,8 @@ export class RedoEditorCommand extends AppCommand {
     /**
      * Executes the command.
      */
-    public execute(): void {
-        this._editor.redo();
+    public async execute(): Promise<void> {
+        await this._editor.redo();
     }
 
 }

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/MappingFileEditor/UndoEditorCommand.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/MappingFileEditor/UndoEditorCommand.ts
@@ -18,13 +18,13 @@ export class UndoEditorCommand extends AppCommand {
         super();
         this._editor = editor;
     }
-    
+
 
     /**
      * Executes the command.
      */
-    public execute(): void {
-        this._editor.undo();
+    public async execute(): Promise<void> {
+        await this._editor.undo();
     }
 
 }

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/NullCommand.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/NullCommand.ts
@@ -13,6 +13,6 @@ export class NullCommand extends AppCommand {
     /**
      * Executes the command.
      */
-    public execute(): void {}
+    public async execute(): Promise<void> {}
 
 }

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/ViewManagement/OpenHyperlink.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/ViewManagement/OpenHyperlink.ts
@@ -22,7 +22,7 @@ export class OpenHyperlink extends AppCommand {
     /**
      * Executes the command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         window.open(this._url, "_blank");
     }
 

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/ViewManagement/SwitchToFullscreen.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/ViewManagement/SwitchToFullscreen.ts
@@ -14,7 +14,7 @@ export class SwitchToFullscreen extends AppCommand {
     /**
      * Executes the command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         const cast = document.body as any;
         if (cast.requestFullscreen) {
             cast.requestFullscreen();

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/DoNothing.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/DoNothing.ts
@@ -13,11 +13,11 @@ export class DoNothing extends EditorCommand {
     /**
      * Executes the editor command.
      */
-    public execute(): void {}
+    public async execute(): Promise<void> {}
 
     /**
      * Undoes the editor command.
      */
-    public undo(): void {}
+    public async undo(): Promise<void> {}
 
 }

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/EditorCommand.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/EditorCommand.ts
@@ -11,40 +11,40 @@ export abstract class EditorCommand {
     /**
      * Executes the editor command.
      */
-    public abstract execute(): void;
+    public abstract execute(): Promise<void>;
 
     /**
      * Executes the editor command.
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public abstract execute(issueDirective?: DirectiveIssuer): void;
+    public abstract execute(issueDirective?: DirectiveIssuer): Promise<void>;
 
     /**
      * Redoes the editor command.
      */
-    public redo(): void;
-    
+    public redo(): Promise<void>;
+
     /**
      * Redoes the editor command.
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public redo(issueDirective?: DirectiveIssuer): void;
-    public redo(issueDirective?: DirectiveIssuer) {
-        this.execute(issueDirective);
+    public async redo(issueDirective?: DirectiveIssuer): Promise<void>;
+    public async redo(issueDirective?: DirectiveIssuer): Promise<void> {
+        return this.execute(issueDirective);
     }
 
     /**
      * Undoes the editor command.
      */
-    abstract undo(): void;
- 
+    abstract undo(): Promise<void>;
+
     /**
      * Undoes the editor command.
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    abstract undo(issueDirective?: DirectiveIssuer): void;
+    abstract undo(issueDirective?: DirectiveIssuer): Promise<void>;
 
 }

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/File/CreateMappingObject.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/File/CreateMappingObject.ts
@@ -7,7 +7,7 @@ export class CreateMappingObject extends EditorCommand {
      * The mapping file.
      */
     public readonly file: MappingFile;
-    
+
     /**
      * The new mapping object to add.
      */
@@ -41,7 +41,7 @@ export class CreateMappingObject extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public execute(issueDirective: DirectiveIssuer = () => {}): void {
+    public async execute(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         this.file.insertMappingObjectAfter(this.object);
         issueDirective(EditorDirective.Record | EditorDirective.Autosave);
         issueDirective(EditorDirective.Reindex, this.object.id);
@@ -52,7 +52,7 @@ export class CreateMappingObject extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public undo(issueDirective: DirectiveIssuer = () => {}): void {
+    public async undo(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         this.file.removeMappingObject(this.object);
         issueDirective(EditorDirective.Autosave);
         issueDirective(EditorDirective.Reindex, this.object.id);

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/File/DeleteMappingObject.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/File/DeleteMappingObject.ts
@@ -7,7 +7,7 @@ export class DeleteMappingObject extends EditorCommand {
      * The object's mapping file.
      */
     public readonly file: MappingFile;
-    
+
     /**
      * The deleted mapping object.
      */
@@ -44,7 +44,7 @@ export class DeleteMappingObject extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public execute(issueDirective: DirectiveIssuer = () => {}): void {
+    public async execute(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         // Remove mapping object
         this.file.removeMappingObject(this.object.id);
         issueDirective(EditorDirective.Record | EditorDirective.Autosave);
@@ -56,7 +56,7 @@ export class DeleteMappingObject extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public undo(issueDirective: DirectiveIssuer = () => {}): void {
+    public async undo(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         // Insert mapping object
         this.file.insertMappingObjectAfter(this.object, this.location);
         issueDirective(EditorDirective.Autosave);

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/File/DeleteMappingObjects.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/File/DeleteMappingObjects.ts
@@ -7,7 +7,7 @@ export class DeleteMappingObjects extends EditorCommand {
      * The objects' mapping file.
      */
     public readonly file: MappingFile | null;
-    
+
     /**
      * The mapping object groups to delete.
      */
@@ -17,12 +17,12 @@ export class DeleteMappingObjects extends EditorCommand {
          * The group's preceding object.
          */
         readonly location: string | undefined,
-        
+
         /**
          * A group of contiguous mapping objects.
          */
         readonly objects: MappingObject[]
-    
+
     }>;
 
 
@@ -85,7 +85,7 @@ export class DeleteMappingObjects extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public execute(issueDirective: DirectiveIssuer = () => {}): void {
+    public async execute(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         if(this.file === null) {
             return;
         }
@@ -108,7 +108,7 @@ export class DeleteMappingObjects extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public undo(issueDirective: DirectiveIssuer = () => {}): void {
+    public async undo(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         if(this.file === null) {
             return;
         }

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/File/ImportMappingObjects.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/File/ImportMappingObjects.ts
@@ -8,7 +8,7 @@ export class ImportMappingObjects extends EditorCommand {
      * The mapping file.
      */
     public readonly file: MappingFile;
-    
+
     /**
      * The new mapping objects to import.
      */
@@ -34,10 +34,10 @@ export class ImportMappingObjects extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public execute(issueDirective: DirectiveIssuer = () => {}): void {
+    public async execute(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         // Create objects
         const file = Reactivity.toRaw(this.file);
-        const objs = new Array<MappingObject>(this.objects.length); 
+        const objs = new Array<MappingObject>(this.objects.length);
         for(let i = 0; i < this.objects.length; i++) {
             objs[i] = file.createMappingObject(this.objects[i]);
         }
@@ -55,7 +55,7 @@ export class ImportMappingObjects extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public undo(issueDirective: DirectiveIssuer = () => {}): void {
+    public async undo(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         // Remove objects
         this.file.removeMappingObjects(this.objects.map(o => o.objectId));
         // Issue directives
@@ -70,6 +70,6 @@ export class ImportMappingObjects extends EditorCommand {
 /**
  * Identified {@link MappingObjectParameters} type definition.
  */
-export type IdentifiedMappingObjectParameters = Omit<MappingObjectParameters, "objectId"> & { 
+export type IdentifiedMappingObjectParameters = Omit<MappingObjectParameters, "objectId"> & {
     objectId: string
 }

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/File/InsertMappingObject.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/File/InsertMappingObject.ts
@@ -7,7 +7,7 @@ export class InsertMappingObject extends EditorCommand {
      * The mapping file.
      */
     public readonly file: MappingFile;
-    
+
     /**
      * The mapping object to insert.
      */
@@ -33,7 +33,7 @@ export class InsertMappingObject extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public execute(issueDirective: DirectiveIssuer = () => {}): void {
+    public async execute(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         this.file.insertMappingObjectAfter(this.object);
         issueDirective(EditorDirective.Record | EditorDirective.Autosave);
         issueDirective(EditorDirective.Reindex, this.object.id);
@@ -44,7 +44,7 @@ export class InsertMappingObject extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public undo(issueDirective: DirectiveIssuer = () => {}): void {
+    public async undo(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         this.file.removeMappingObject(this.object);
         issueDirective(EditorDirective.Autosave);
         issueDirective(EditorDirective.Reindex, this.object.id);

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/File/InsertMappingObjects.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/File/InsertMappingObjects.ts
@@ -7,7 +7,7 @@ export class InsertMappingObjects extends EditorCommand {
      * The mapping file.
      */
     public readonly file: MappingFile;
-    
+
     /**
      * The mapping objects to insert.
      */
@@ -33,7 +33,7 @@ export class InsertMappingObjects extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public execute(issueDirective: DirectiveIssuer = () => {}): void {
+    public async execute(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         this.file.insertMappingObjectsAfter(this.objects);
         issueDirective(EditorDirective.Record | EditorDirective.Autosave);
         for(const obj of this.objects) {
@@ -46,7 +46,7 @@ export class InsertMappingObjects extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public undo(issueDirective: DirectiveIssuer = () => {}): void {
+    public async undo(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         this.file.removeMappingObjects(this.objects);
         issueDirective(EditorDirective.Autosave);
         for(const obj of this.objects) {

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/File/MoveMappingObjectAfter.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/File/MoveMappingObjectAfter.ts
@@ -7,7 +7,7 @@ export class MoveMappingObjectAfter extends EditorCommand {
      * The mapping file.
      */
     public readonly file: MappingFile;
-    
+
     /**
      * The id of the object to move.
      */
@@ -51,7 +51,7 @@ export class MoveMappingObjectAfter extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public execute(issueDirective: DirectiveIssuer = () => {}): void {
+    public async execute(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         this.file.removeMappingObject(this.object);
         this.file.insertMappingObjectAfter(this.object, this.nextLocation);
         issueDirective(EditorDirective.Record | EditorDirective.Autosave);
@@ -62,7 +62,7 @@ export class MoveMappingObjectAfter extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public undo(issueDirective: DirectiveIssuer = () => {}): void {
+    public async undo(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         this.file.removeMappingObject(this.object);
         this.file.insertMappingObjectAfter(this.object, this.prevLocation);
         issueDirective(EditorDirective.Autosave);

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/File/MoveMappingObjectsAfter.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/File/MoveMappingObjectsAfter.ts
@@ -7,7 +7,7 @@ export class MoveMappingObjectsAfter extends EditorCommand {
      * The mapping file.
      */
     public readonly file: MappingFile;
-    
+
     /**
      * The id of the object to move.
      */
@@ -51,7 +51,7 @@ export class MoveMappingObjectsAfter extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public execute(issueDirective: DirectiveIssuer = () => {}): void {
+    public async execute(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         this.file.removeMappingObject(this.object);
         this.file.insertMappingObjectAfter(this.object, this.nextLocation);
         issueDirective(EditorDirective.Record | EditorDirective.Autosave);
@@ -62,7 +62,7 @@ export class MoveMappingObjectsAfter extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public undo(issueDirective: DirectiveIssuer = () => {}): void {
+    public async undo(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         this.file.removeMappingObject(this.object);
         this.file.insertMappingObjectAfter(this.object, this.prevLocation);
         issueDirective(EditorDirective.Autosave);

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/File/ReindexMappingObjects.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/File/ReindexMappingObjects.ts
@@ -21,7 +21,7 @@ export class ReindexMappingObjects extends EditorCommand {
      *  The mapping object's id.
      */
     constructor(ids: string);
-    
+
     /**
      * Reindexes a set of mapping objects.
      * @remarks
@@ -46,7 +46,7 @@ export class ReindexMappingObjects extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public execute(issueDirective: DirectiveIssuer = () => {}): void {
+    public async execute(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         for(const id of this.ids) {
             issueDirective(EditorDirective.Reindex, id);
         }
@@ -57,7 +57,7 @@ export class ReindexMappingObjects extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public undo(issueDirective: DirectiveIssuer = () => {}): void {
+    public async undo(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         for(const id of this.ids) {
             issueDirective(EditorDirective.Reindex, id);
         }

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/GroupCommand.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/GroupCommand.ts
@@ -25,7 +25,7 @@ export class GroupCommand extends EditorCommand {
      * Executes a series of editor commands.
      */
     constructor();
-    
+
     /**
      * Executes a series of editor commands.
      * @param reverseCommandsOnUndo
@@ -46,7 +46,7 @@ export class GroupCommand extends EditorCommand {
         this._reverseCommandsOnUndo = reverseCommandsOnUndo;
         this._rollbackOnFailure = rollbackOnFailure;
     }
-    
+
 
     /**
      * Appends a command to the command sequence.
@@ -65,8 +65,8 @@ export class GroupCommand extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public execute(issueDirective: DirectiveIssuer = () => {}): void {
-        this._execute("execute", issueDirective);
+    public async execute(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
+        return this._execute("execute", issueDirective);
     }
 
     /**
@@ -74,8 +74,8 @@ export class GroupCommand extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public redo(issueDirective: DirectiveIssuer = () => {}): void {
-        this._execute("redo", issueDirective);
+    public async redo(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
+        return this._execute("redo", issueDirective);
     }
 
     /**
@@ -83,16 +83,16 @@ export class GroupCommand extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public undo(issueDirective: DirectiveIssuer = () => {}): void {
+    public async undo(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         // Run first phase
         if(this._reverseCommandsOnUndo) {
             const l = this._commands.length - 1;
             for(let i = l; 0 <= i; i--) {
-                this._commands[i].undo(issueDirective);
+                await this._commands[i].undo(issueDirective);
             }
         } else {
             for(let i = 0; i < this._commands.length; i++) {
-                this._commands[i].undo(issueDirective);
+                await this._commands[i].undo(issueDirective);
             }
         }
     }
@@ -104,26 +104,26 @@ export class GroupCommand extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    private _execute(func: "execute" | "redo", issueDirective: DirectiveIssuer) { 
+    private async _execute(func: "execute" | "redo", issueDirective: DirectiveIssuer) {
         let i = 0;
         try {
             for(; i < this._commands.length; i++) {
-                this._commands[i][func](issueDirective);
+                await this._commands[i][func](issueDirective);
             }
         } catch (ex) {
             if(this._rollbackOnFailure) {
                 if(this._reverseCommandsOnUndo) {
                     for(i--; 0 <= i; i--) {
-                        this._commands[i].undo();
+                        await this._commands[i].undo();
                     }
                 } else {
                     for(let j = 0; j < i; j++) {
-                        this._commands[j].undo();
+                        await this._commands[j].undo();
                     }
                 }
             }
             throw ex;
         }
-    } 
+    }
 
 }

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/Property/AddItemToListProperty.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/Property/AddItemToListProperty.ts
@@ -17,7 +17,7 @@ export class AddItemToListProperty extends EditorCommand {
      * The property.
      */
     public readonly prop: ListProperty;
-    
+
 
     /**
      * Adds a {@link ListItem} to a {@link ListProperty}.
@@ -34,14 +34,14 @@ export class AddItemToListProperty extends EditorCommand {
         this.item = item;
         this.index = index;
     }
-    
+
 
     /**
      * Executes the editor command.
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    execute(issueDirective: DirectiveIssuer = () => {}): void {
+    public async execute(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         this.prop.insertListItem(this.item, this.index);
         issueDirective(EditorDirective.Record | EditorDirective.Autosave);
     }
@@ -51,7 +51,7 @@ export class AddItemToListProperty extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    undo(issueDirective: DirectiveIssuer = () => {}): void {
+    public async undo(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         this.prop.removeListItem(this.item);
         issueDirective(EditorDirective.Autosave);
     }

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/Property/DeleteItemFromListProperty.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/Property/DeleteItemFromListProperty.ts
@@ -17,7 +17,7 @@ export class DeleteItemFromListProperty extends EditorCommand {
      * The property.
      */
     public readonly prop: ListProperty;
-    
+
 
     /**
      * Deletes a {@link ListItem} from a {@link ListProperty}.
@@ -35,14 +35,14 @@ export class DeleteItemFromListProperty extends EditorCommand {
             throw new Error(`List does not contain item '${ item.id }'.`)
         }
     }
-    
+
 
     /**
      * Executes the editor command.
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    execute(issueDirective: DirectiveIssuer = () => {}): void {
+    public async execute(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         this.prop.removeListItem(this.item);
         issueDirective(EditorDirective.Record | EditorDirective.Autosave);
     }
@@ -52,7 +52,7 @@ export class DeleteItemFromListProperty extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    undo(issueDirective: DirectiveIssuer = () => {}): void {
+    public async undo(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         this.prop.insertListItem(this.item, this.index);
         issueDirective(EditorDirective.Autosave);
     }

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/Property/EnterDynamicFrameworkObjectProperty.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/Property/EnterDynamicFrameworkObjectProperty.ts
@@ -7,7 +7,7 @@ export class EnterDynamicFrameworkObjectProperty extends EditorCommand {
      * The property to enter.
      */
     public readonly prop: DynamicFrameworkObjectProperty;
-    
+
 
     /**
      * Enters a {@link DynamicFrameworkObjectProperty}.
@@ -18,18 +18,18 @@ export class EnterDynamicFrameworkObjectProperty extends EditorCommand {
         super();
         this.prop = prop;
     }
-    
+
 
     /**
      * Executes the editor command.
      */
-    execute(): void {
+    public async execute(): Promise<void> {
         this.prop.isTargeted = true;
     }
 
     /**
      * Undoes the editor command.
      */
-    undo(): void {}
+    public async undo(): Promise<void> {}
 
 }

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/Property/ExitDynamicFrameworkObjectProperty.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/Property/ExitDynamicFrameworkObjectProperty.ts
@@ -7,7 +7,7 @@ export class ExitDynamicFrameworkObjectProperty extends EditorCommand {
      * The property to exit.
      */
     public readonly prop: DynamicFrameworkObjectProperty;
-    
+
 
     /**
      * Exits a {@link DynamicFrameworkObjectProperty}.
@@ -18,18 +18,18 @@ export class ExitDynamicFrameworkObjectProperty extends EditorCommand {
         super();
         this.prop = prop;
     }
-    
+
 
     /**
      * Executes the editor command.
      */
-    execute(): void {
+    public async execute(): Promise<void> {
         this.prop.isTargeted = false;
     }
 
     /**
      * Undoes the editor command.
      */
-    undo(): void {}
+    public async undo(): Promise<void> {}
 
 }

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/Property/SetFrameworkObjectPropertyId.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/Property/SetFrameworkObjectPropertyId.ts
@@ -27,7 +27,7 @@ export class SetFrameworkObjectPropertyId extends EditorCommand {
      * The property.
      */
     public readonly prop: FrameworkObjectProperty;
-    
+
 
     /**
      * Sets the object id of a {@link FrameworkObjectProperty}.
@@ -63,14 +63,14 @@ export class SetFrameworkObjectPropertyId extends EditorCommand {
             this.prevObjectId = prop.objectId;
         }
     }
-    
+
 
     /**
      * Executes the editor command.
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    execute(issueDirective: DirectiveIssuer = () => {}): void {
+    public async execute(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         if(this.nextObjectId && this.nextObjectText !== undefined) {
             this.prop.setObjectValue(this.nextObjectId, this.nextObjectText);
         } else {
@@ -84,7 +84,7 @@ export class SetFrameworkObjectPropertyId extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    undo(issueDirective: DirectiveIssuer = () => {}): void {
+    public async undo(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         if(this.prevObjectId && this.prevObjectText !== undefined) {
             this.prop.setObjectValue(this.prevObjectId, this.prevObjectText);
         } else {

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/Property/SetFrameworkObjectPropertyText.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/Property/SetFrameworkObjectPropertyText.ts
@@ -17,7 +17,7 @@ export class SetFrameworkObjectPropertyText extends EditorCommand {
      * The property.
      */
     public readonly prop: FrameworkObjectProperty;
-    
+
 
     /**
      * Sets the object text of a {@link FrameworkObjectProperty}.
@@ -32,14 +32,14 @@ export class SetFrameworkObjectPropertyText extends EditorCommand {
         this.prevObjectText = prop.objectText;
         this.nextObjectText = objectText;
     }
-    
+
 
     /**
      * Executes the editor command.
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    execute(issueDirective: DirectiveIssuer = () => {}): void {
+    public async execute(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         this.prop.objectText = this.nextObjectText;
         issueDirective(EditorDirective.Record | EditorDirective.Autosave);
     }
@@ -49,7 +49,7 @@ export class SetFrameworkObjectPropertyText extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    undo(issueDirective: DirectiveIssuer = () => {}): void {
+    public async undo(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         this.prop.objectText = this.prevObjectText;
         issueDirective(EditorDirective.Autosave);
     }

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/Property/SetListItemProperty.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/Property/SetListItemProperty.ts
@@ -27,7 +27,7 @@ export class SetListItemProperty extends EditorCommand {
      * The property.
      */
     public readonly prop: ListItemProperty;
-    
+
 
     /**
      * Sets the value of a {@link ListItemProperty}.
@@ -55,7 +55,7 @@ export class SetListItemProperty extends EditorCommand {
         this.nextValue = param1;
         if(param2 !== undefined) {
             this.nextExportText = param2;
-        } 
+        }
         // Configure prev value
         if(prop.isValueCached()) {
             this.prevValue = prop.exportValue;
@@ -64,14 +64,14 @@ export class SetListItemProperty extends EditorCommand {
             this.prevValue = prop.value;
         }
     }
-    
+
 
     /**
      * Executes the editor command.
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    execute(issueDirective: DirectiveIssuer = () => {}): void {
+    public async execute(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         if(this.nextValue && this.nextExportText !== undefined) {
             this.prop.setValue(this.nextValue, this.nextExportText);
         } else {
@@ -85,7 +85,7 @@ export class SetListItemProperty extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    undo(issueDirective: DirectiveIssuer = () => {}): void {
+    public async undo(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         if(this.prevValue && this.prevExportText !== undefined) {
             this.prop.setValue(this.prevValue, this.prevExportText);
         } else {

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/Property/SetStringProperty.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/Property/SetStringProperty.ts
@@ -17,7 +17,7 @@ export class SetStringProperty extends EditorCommand {
      * The property.
      */
     public readonly prop: StringProperty;
-    
+
 
     /**
      * Sets the value of a {@link StringProperty}.
@@ -32,14 +32,14 @@ export class SetStringProperty extends EditorCommand {
         this.prevValue = prop.value;
         this.nextValue = value;
     }
-    
+
 
     /**
      * Executes the editor command.
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    execute(issueDirective: DirectiveIssuer = () => {}): void {
+    public async execute(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         this.prop.value = this.nextValue;
         issueDirective(EditorDirective.Record | EditorDirective.Autosave);
     }
@@ -49,7 +49,7 @@ export class SetStringProperty extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    undo(issueDirective: DirectiveIssuer = () => {}): void {
+    public async undo(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         this.prop.value = this.prevValue;
         issueDirective(EditorDirective.Autosave);
     }

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/CollapseAllMappingObjectViews.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/CollapseAllMappingObjectViews.ts
@@ -31,13 +31,13 @@ export class CollapseAllMappingObjectViews extends EditorCommand {
     /**
      * Executes the editor command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         this.fileView.setAllItemsCollapse(this.value, o => o instanceof MappingObjectView);
     }
 
     /**
      * Undoes the editor command.
      */
-    public undo(): void {}
+    public async undo(): Promise<void> {}
 
 }

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/CollapseViewItem.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/CollapseViewItem.ts
@@ -7,7 +7,7 @@ export class CollapseViewItem extends EditorCommand {
      * The mapping file view.
      */
     public readonly fileView: MappingFileView;
-    
+
     /**
      * The view item to collapse.
      */
@@ -45,7 +45,7 @@ export class CollapseViewItem extends EditorCommand {
      * @param issueDirective
      *  A function that can issue one or more editor directives.
      */
-    public execute(issueDirective: DirectiveIssuer = () => {}): void {
+    public async execute(issueDirective: DirectiveIssuer = () => {}): Promise<void> {
         this.item.collapsed = this.nextValue;
         if(this.item instanceof MappingObjectView) {
             issueDirective(EditorDirective.Record);
@@ -55,7 +55,7 @@ export class CollapseViewItem extends EditorCommand {
     /**
      * Undoes the editor command.
      */
-    public undo(): void {
+    public async undo(): Promise<void> {
         this.item.collapsed = this.prevValue;
     }
 

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/MoveBreakout.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/MoveBreakout.ts
@@ -7,7 +7,7 @@ export class MoveBreakout extends EditorCommand {
      * The mapping file view.
      */
     public readonly fileView: MappingFileView;
-    
+
     /**
      * The breakout control.
      */
@@ -45,13 +45,13 @@ export class MoveBreakout extends EditorCommand {
     /**
      * Executes the editor command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         this.control.moveBreakout(this.id, this.dst);
     }
 
     /**
      * Undoes the editor command.
      */
-    public undo(): void {}
+    public async undo(): Promise<void> {}
 
 }

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/MoveCameraToViewItem.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/MoveCameraToViewItem.ts
@@ -12,7 +12,7 @@ export class MoveCameraToViewItem extends EditorCommand {
      * The view item's id.
      */
     public readonly id: string;
-    
+
     /**
      * The camera's position upon execute.
      */
@@ -32,7 +32,7 @@ export class MoveCameraToViewItem extends EditorCommand {
     /**
      * Moves the camera to a {@link MappingFileViewItem}. This command
      * allows you to set the camera position for each command state
-     * (i.e. execute, undo, and redo). 
+     * (i.e. execute, undo, and redo).
      * @param view
      *  The view item.
      * @param execPosition
@@ -52,7 +52,7 @@ export class MoveCameraToViewItem extends EditorCommand {
     /**
      * Moves the camera to a {@link MappingFileViewItem}. This command
      * allows you to set the camera position for each command state
-     * (i.e. execute, undo, and redo). 
+     * (i.e. execute, undo, and redo).
      * @param fileView
      *  The mapping file view to operate on.
      * @param id
@@ -100,21 +100,21 @@ export class MoveCameraToViewItem extends EditorCommand {
     /**
      * Executes the editor command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         this.move(this.execPosition);
     }
 
     /**
      * Redoes the editor command.
      */
-    public redo(): void {
+    public async redo(): Promise<void> {
         this.move(this.redoPosition);
     }
 
     /**
      * Undoes the editor command.
      */
-    public undo(): void {
+    public async undo(): Promise<void> {
         this.move(this.undoPosition);
     }
 
@@ -133,7 +133,7 @@ export class MoveCameraToViewItem extends EditorCommand {
 }
 
 type CameraPosition = {
-    
+
     /**
      * The view item's location in the viewport.
      */

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/RebuildViewBreakouts.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/RebuildViewBreakouts.ts
@@ -7,7 +7,7 @@ export class RebuildViewBreakouts extends EditorCommand {
      */
     public readonly fileView: MappingFileView;
 
-    
+
     /**
      * Rebuilds a {@link MappingFileView}'s breakouts.
      * @param fileView
@@ -22,14 +22,14 @@ export class RebuildViewBreakouts extends EditorCommand {
     /**
      * Executes the editor command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         this.fileView.rebuildBreakouts();
     }
 
     /**
      * Undoes the editor command.
      */
-    public undo(): void {
+    public async undo(): Promise<void> {
         this.fileView.rebuildBreakouts();
     }
 

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/RestoreMappingObjectViews.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/RestoreMappingObjectViews.ts
@@ -32,12 +32,12 @@ export class RestoreMappingObjectViews extends EditorCommand {
     /**
      * Executes the editor command.
      */
-    public execute(): void {}
+    public async execute(): Promise<void> {}
 
     /**
      * Undoes the editor command.
      */
-    public undo(): void {
+    public async undo(): Promise<void> {
         if(this.views.length) {
             const file = this.views[0].fileView;
             for(const view of this.views) {

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/SelectAllMappingObjectViews.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/SelectAllMappingObjectViews.ts
@@ -25,7 +25,7 @@ export class SelectAllMappingObjectViews extends EditorCommand {
 
     /**
      * Custom select behavior for all {@link MappingObjectView}s within a
-     * {@link MappingFileView}. This command allows you to set the select state 
+     * {@link MappingFileView}. This command allows you to set the select state
      * for each command state (i.e. execute and undo).
      * @param fileView
      *  The mapping file view to operate on.
@@ -38,7 +38,7 @@ export class SelectAllMappingObjectViews extends EditorCommand {
 
     /**
      * Custom select behavior for all {@link MappingObjectView}s within a
-     * {@link MappingFileView}. This command allows you to set the select state 
+     * {@link MappingFileView}. This command allows you to set the select state
      * for each command state (i.e. execute, undo, and redo).
      * @param fileView
      *  The mapping file view to operate on.
@@ -62,21 +62,21 @@ export class SelectAllMappingObjectViews extends EditorCommand {
     /**
      * Executes the editor command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         this.select(this.execSelect);
     }
 
     /**
      * Redoes the editor command.
      */
-    public redo(): void {
+    public async redo(): Promise<void> {
         this.select(this.redoSelect);
     }
 
     /**
      * Undoes the editor command.
      */
-    public undo(): void {
+    public async undo(): Promise<void> {
         this.select(this.undoSelect);
 
     }

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/SelectMappingObjectViews.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/SelectMappingObjectViews.ts
@@ -42,7 +42,7 @@ export class SelectMappingObjectViews extends EditorCommand {
      *  The item's select state upon redo.
      */
     constructor(
-        view: MappingObjectView, 
+        view: MappingObjectView,
         execSelect?: SelectOptions | boolean,
         undoSelect?: SelectOptions | boolean,
         redoSelect?: SelectOptions | boolean
@@ -62,7 +62,7 @@ export class SelectMappingObjectViews extends EditorCommand {
      *  The item's select state upon redo.
      */
     constructor(
-        views: MappingObjectView[], 
+        views: MappingObjectView[],
         execSelect?: SelectOptions | boolean,
         undoSelect?: SelectOptions | boolean,
         redoSelect?: SelectOptions | boolean
@@ -84,7 +84,7 @@ export class SelectMappingObjectViews extends EditorCommand {
      *  The item's select state upon redo.
      */
     constructor(
-        fileView: MappingFileView, 
+        fileView: MappingFileView,
         id: string,
         execSelect?: SelectOptions | boolean,
         undoSelect?: SelectOptions | boolean,
@@ -107,7 +107,7 @@ export class SelectMappingObjectViews extends EditorCommand {
      *  The item's select state upon redo.
      */
     constructor(
-        fileView: MappingFileView, 
+        fileView: MappingFileView,
         ids: string[],
         execSelect?: SelectOptions | boolean,
         undoSelect?: SelectOptions | boolean,
@@ -165,21 +165,21 @@ export class SelectMappingObjectViews extends EditorCommand {
     /**
      * Executes the editor command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         this.select(this.execSelect);
     }
 
     /**
      * Redoes the editor command.
      */
-    public redo(): void {
+    public async redo(): Promise<void> {
         this.select(this.redoSelect);
     }
 
     /**
      * Undoes the editor command.
      */
-    public undo(): void {
+    public async undo(): Promise<void> {
         this.select(this.undoSelect);
     }
 
@@ -214,7 +214,7 @@ export class SelectMappingObjectViews extends EditorCommand {
             }
             for(const view of this.view) {
                 view.select(select);
-            }   
+            }
         }
     }
 

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/SetBreakoutState.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/SetBreakoutState.ts
@@ -2,7 +2,7 @@ import { EditorCommand } from "..";
 import type { BreakoutControl, MappingFileView } from "../..";
 
 export class SetBreakoutState extends EditorCommand {
-    
+
     /**
      * The mapping file view.
      */
@@ -45,13 +45,13 @@ export class SetBreakoutState extends EditorCommand {
     /**
      * Executes the editor command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         this.control.setBreakoutState(this.id, this.value);
     }
 
     /**
      * Undoes the editor command.
      */
-    public undo(): void {}
+    public async undo(): Promise<void> {}
 
 }

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/SetFilterState.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/SetFilterState.ts
@@ -2,7 +2,7 @@ import { EditorCommand } from "..";
 import type { FilterControl, MappingFileView } from "../..";
 
 export class SetFilterState extends EditorCommand {
-    
+
     /**
      * The mapping file view.
      */
@@ -45,7 +45,7 @@ export class SetFilterState extends EditorCommand {
     /**
      * Executes the editor command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         if(this.value) {
             this.control.show(this.id);
         } else {
@@ -56,6 +56,6 @@ export class SetFilterState extends EditorCommand {
     /**
      * Undoes the editor command.
      */
-    public undo(): void {}
+    public async undo(): Promise<void> {}
 
 }

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/SetMappingFileViewHeight.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/SetMappingFileViewHeight.ts
@@ -31,13 +31,13 @@ export class SetMappingFileViewHeight extends EditorCommand {
     /**
      * Executes the editor command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         this.fileView.setViewHeight(this.height);
     }
 
     /**
      * Undoes the editor command.
      */
-    public undo(): void {}
+    public async undo(): Promise<void> {}
 
 }

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/SetMappingFileViewPosition.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/SetMappingFileViewPosition.ts
@@ -31,13 +31,13 @@ export class SetMappingFileViewPosition extends EditorCommand {
     /**
      * Executes the editor command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         this.fileView.setViewPosition(this.position);
     }
 
     /**
      * Undoes the editor command.
      */
-    public undo(): void {}
+    public async undo(): Promise<void> {}
 
 }

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/ShowAllItems.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/EditorCommands/View/ShowAllItems.ts
@@ -29,13 +29,13 @@ export class ShowAllItems extends EditorCommand {
     /**
      * Executes the editor command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         this.control.showAll();
     }
 
     /**
      * Undoes the editor command.
      */
-    public undo(): void {}
+    public async undo(): Promise<void> {}
 
 }

--- a/src/mappings_editor/src/assets/scripts/MappingFileEditor/MappingFileEditor.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileEditor/MappingFileEditor.ts
@@ -82,7 +82,7 @@ export class MappingFileEditor extends EventEmitter<MappingFileEditorEvents> {
      * The editor's search index.
      */
     private _searchIndex: Document<MappingObjectDocument>;
-    
+
 
     /**
      * The last time the editor autosaved.
@@ -166,7 +166,7 @@ export class MappingFileEditor extends EventEmitter<MappingFileEditorEvents> {
      * @returns
      *  The command directives.
      */
-    public execute(...commands: EditorCommand[]) {
+    public async execute(...commands: EditorCommand[]) {
         // Package command
         let cmd: EditorCommand;
         if (commands.length === 0) {
@@ -183,7 +183,7 @@ export class MappingFileEditor extends EventEmitter<MappingFileEditorEvents> {
         // Construct arguments
         const { args, issuer } = this.newDirectiveArguments();
         // Execute command
-        cmd.execute(issuer);
+        await cmd.execute(issuer);
         if (args.directives & EditorDirective.Record) {
             this._redoStack = [];
             this._undoStack.push(cmd);
@@ -246,13 +246,13 @@ export class MappingFileEditor extends EventEmitter<MappingFileEditorEvents> {
     /**
      * Undoes the last editor command.
      */
-    public undo() {
+    public async undo() {
         if (this._undoStack.length) {
             // Construct arguments
             const { args, issuer } = this.newDirectiveArguments();
             // Execute undo
             const cmd = this._undoStack[this._undoStack.length - 1];
-            cmd.undo(issuer);
+            await cmd.undo(issuer);
             this._redoStack.push(this._undoStack.pop()!);
             this.executeDirectives(args);
         }
@@ -270,13 +270,13 @@ export class MappingFileEditor extends EventEmitter<MappingFileEditorEvents> {
     /**
      * Redoes the last undone editor command.
      */
-    public redo() {
+    public async redo() {
         if (this._redoStack.length) {
             // Construct arguments
             const { args, issuer } = this.newDirectiveArguments();
             // Execute redo
             const cmd = this._redoStack[this._redoStack.length - 1];
-            cmd.redo(issuer);
+            await cmd.redo(issuer);
             this._undoStack.push(this._redoStack.pop()!);
             this.executeDirectives(args);
         }
@@ -291,7 +291,7 @@ export class MappingFileEditor extends EventEmitter<MappingFileEditorEvents> {
         return 0 < this._redoStack.length;
     }
 
-    
+
     ///////////////////////////////////////////////////////////////////////////
     //  3. Autosave  //////////////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////
@@ -432,7 +432,7 @@ export class MappingFileEditor extends EventEmitter<MappingFileEditorEvents> {
         }
         return results;
     }
-    
+
 
     ///////////////////////////////////////////////////////////////////////////
     //  6. Phantom  ///////////////////////////////////////////////////////////

--- a/src/mappings_editor/src/components/Controls/MappingFileSearch.vue
+++ b/src/mappings_editor/src/components/Controls/MappingFileSearch.vue
@@ -26,12 +26,12 @@
     </template>
   </div>
 </template>
-  
+
 <script lang="ts">
 import * as EditorCommands from "@/assets/scripts/MappingFileEditor/EditorCommands";
 import { unsignedMod } from "@/assets/scripts/Utilities";
 import { defineComponent, type PropType } from 'vue';
-import type { 
+import type {
   EditorCommand,
   MappingFileEditor,
   MappingFileViewItem,
@@ -114,7 +114,7 @@ export default defineComponent({
       }
       // Update total items
       this.searchCount[1] = results.length;
-      // If no matches, bail 
+      // If no matches, bail
       if(results.length === 0) {
         this.searchCount[0] = 0;
         return;
@@ -175,7 +175,7 @@ export default defineComponent({
   }
 });
 </script>
-  
+
 <style scoped>
 
 /** === Main Control === */

--- a/src/mappings_editor/src/stores/ApplicationStore.ts
+++ b/src/mappings_editor/src/stores/ApplicationStore.ts
@@ -64,13 +64,13 @@ export const useApplicationStore = defineStore('applicationStore', {
          * @param command
          *  The application command.
          */
-        execute(command: AppCommand | EditorCommand) {
+        async execute(command: AppCommand | EditorCommand) {
             if(command instanceof EditorCommand) {
                 // Execute editor command
-                this.activeEditor.execute(command);
+                await this.activeEditor.execute(command);
             } else {
                 // Execute application command
-                command.execute();
+                await command.execute();
             }
             // Temporarily hold any autosaving
             this.activeEditor.tryDelayAutosave();


### PR DESCRIPTION
Fixes #210

## What Changed
Allows:
- Any `AppCommand` to perform asynchronous work in `execute()`.
- Any `EditorCommand` to perform asynchronous work in `execute()`, `undo()`, or `redo()`. 

All existing commands have been refactored to match this new paradigm.

## Known Limitations
None