### PR TITLE
MAPEX-209: User Registered Frameworks

### DIFF
--- a/src/mappings_editor/public/settings_macos.json
+++ b/src/mappings_editor/public/settings_macos.json
@@ -4,6 +4,7 @@
             "new_file": "Meta+N",
             "open_file": "Meta+O",
             "import_file": "Meta+I",
+            "register_framework": "",
             "save_file": "Meta+S"
         },
         "edit": {

--- a/src/mappings_editor/public/settings_win.json
+++ b/src/mappings_editor/public/settings_win.json
@@ -4,6 +4,7 @@
             "new_file": "Control+N",
             "open_file": "Control+O",
             "import_file": "Control+I",
+            "register_framework": "",
             "save_file": "Control+S"
         },
         "edit": {

--- a/src/mappings_editor/src/App.vue
+++ b/src/mappings_editor/src/App.vue
@@ -203,6 +203,22 @@ export default defineComponent({
     await this.application.execute(AppCommands.loadSettings(this.application, settings));
     // Load file from query parameters, if possible
     let params = new URLSearchParams(window.location.search);
+    // Load framework from query parameters, if possible
+    let frm = params.getAll("framework");
+    if(frm.length) {
+      // Setup registrations
+      const registrations = frm.map(f => {
+        AppCommands.registerFrameworkFromUrl(this.application, f)
+          .then(cmd => this.application.execute(cmd))
+          .catch(ex => {
+            console.error(`Failed to register framework from url: '${ frm }'`);
+            console.error(ex);
+          })
+      });
+      // Await registrations
+      await Promise.all(registrations);
+    }
+    // Load file from query parameters, if possible
     let src = params.get("src");
     if(src) {
       try {

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/ApplicationSettings/LoadFramework.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/ApplicationSettings/LoadFramework.ts
@@ -1,0 +1,22 @@
+import { GroupCommand } from "../GroupCommand";
+import { RegisterFramework } from "./RegisterFramework";
+import { StoreFrameworkToBank } from "./StoreFrameworkToBank";
+import { FrameworkSourceFile, type Framework } from "@/assets/scripts/MappingFileAuthority";
+import type { ApplicationStore } from "@/stores/ApplicationStore";
+
+export class LoadFrameworkFile extends GroupCommand {
+
+    /**
+     * Registers and saves a framework to the application's Framework Bank.
+     * @param context
+     *  The application context.
+     * @param file
+     *  The framework file.
+     */
+    constructor(context: ApplicationStore, file: Framework) {
+        super();
+        this.add(new StoreFrameworkToBank(context, file))
+        this.add(new RegisterFramework(context, new FrameworkSourceFile(file)));
+    }
+
+}

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/ApplicationSettings/RegisterFramework.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/ApplicationSettings/RegisterFramework.ts
@@ -36,22 +36,20 @@ export class RegisterFramework extends AppCommand {
     /**
      * Executes the command.
      */
-    public execute(): void {
+    public async execute(): Promise<void> {
         // Create raw references
         const fileAuthority = toRaw(this.context.fileAuthority);
         // Register framework
         fileAuthority.registry.registerFramework(this.framework);
-        // Export
+        // Reload open file
         const { id, version: ver } = this.framework;
         const file = toRaw(this.context.activeEditor.file) as MappingFile;
         if(
             (id === file.sourceFramework && ver === file.sourceVersion) ||
             (id === file.targetFramework && ver === file.targetVersion)
         ) {
-            fileAuthority.reloadMappingFile(file).then(file => {
-                this.context.activeEditor.tryDispatchOutstandingAutosave();
-                this.context.execute(new LoadFile(this.context, file));
-            });
+            const reloadedFile = await fileAuthority.reloadMappingFile(file);
+            new LoadFile(this.context, reloadedFile).execute();
         }
     }
 

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/ApplicationSettings/RegisterFramework.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/ApplicationSettings/RegisterFramework.ts
@@ -1,10 +1,9 @@
 import { toRaw } from "vue";
+import { LoadFile } from "../FileManagement/LoadFile";
 import { AppCommand } from "../AppCommand";
-import { MappingFileEditor } from "@/assets/scripts/MappingFileEditor";
 import type { MappingFile } from "@/assets/scripts/MappingFile";
 import type { FrameworkSource } from "@/assets/scripts/MappingFileAuthority";
 import type { ApplicationStore } from "@/stores/ApplicationStore";
-import { LoadFile } from "../FileManagement/LoadFile";
 
 export class RegisterFramework extends AppCommand {
 

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/ApplicationSettings/RegisterFramework.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/ApplicationSettings/RegisterFramework.ts
@@ -1,0 +1,58 @@
+import { toRaw } from "vue";
+import { AppCommand } from "../AppCommand";
+import { MappingFileEditor } from "@/assets/scripts/MappingFileEditor";
+import type { MappingFile } from "@/assets/scripts/MappingFile";
+import type { FrameworkSource } from "@/assets/scripts/MappingFileAuthority";
+import type { ApplicationStore } from "@/stores/ApplicationStore";
+import { LoadFile } from "../FileManagement/LoadFile";
+
+export class RegisterFramework extends AppCommand {
+
+    /**
+     * The framework's source.
+     */
+    public readonly framework: FrameworkSource;
+
+    /**
+     * The application context.
+     */
+    public readonly context: ApplicationStore;
+
+
+    /**
+     * Registers a Framework with the application.
+     * @param context
+     *  The application context.
+     * @param framework
+     *  The framework's source.
+     */
+    constructor(context: ApplicationStore, framework: FrameworkSource) {
+        super();
+        this.context = context;
+        this.framework = framework;
+    }
+
+
+    /**
+     * Executes the command.
+     */
+    public execute(): void {
+        // Create raw references
+        const fileAuthority = toRaw(this.context.fileAuthority);
+        // Register framework
+        fileAuthority.registry.registerFramework(this.framework);
+        // Export
+        const { id, version: ver } = this.framework;
+        const file = toRaw(this.context.activeEditor.file) as MappingFile;
+        if(
+            (id === file.sourceFramework && ver === file.sourceVersion) ||
+            (id === file.targetFramework && ver === file.targetVersion)
+        ) {
+            fileAuthority.reloadMappingFile(file).then(file => {
+                this.context.activeEditor.tryDispatchOutstandingAutosave();
+                this.context.execute(new LoadFile(this.context, file));
+            });
+        }
+    }
+
+}

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/ApplicationSettings/StoreFrameworkToBank.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/ApplicationSettings/StoreFrameworkToBank.ts
@@ -1,0 +1,42 @@
+import { AppCommand } from "../AppCommand";
+import type { Framework } from "@/assets/scripts/MappingFileAuthority";
+import type { ApplicationStore } from "@/stores/ApplicationStore";
+
+export class StoreFrameworkToBank extends AppCommand {
+
+    /**
+     * The framework.
+     */
+    public readonly framework: Framework;
+
+    /**
+     * The application context.
+     */
+    public readonly context: ApplicationStore;
+
+
+    /**
+     * Stores a framework in the application's Framework Bank.
+     * @param context
+     *  The application context.
+     * @param framework
+     *  The framework.
+     */
+    constructor(context: ApplicationStore, framework: Framework) {
+        super();
+        this.context = context;
+        this.framework = framework;
+    }
+
+
+    /**
+     * Executes the command.
+     */
+    public async execute(): Promise<void> {
+        const { frameworkId, frameworkVersion } = this.framework;
+        const id = `${frameworkId}@${frameworkVersion}`;
+        const name = JSON.stringify({ id: frameworkId, version: frameworkVersion });
+        this.context.frameworkBank.saveFile(id, name, JSON.stringify(this.framework));
+    }
+
+}

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/ApplicationSettings/UnloadStoredFrameworks.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/ApplicationSettings/UnloadStoredFrameworks.ts
@@ -1,0 +1,57 @@
+import { toRaw } from "vue";
+import { LoadFile } from "../FileManagement/LoadFile";
+import { AppCommand } from "../AppCommand";
+import type { ApplicationStore } from "@/stores/ApplicationStore";
+import type { MappingFile } from "@/assets/scripts/MappingFile";
+
+export class UnloadStoredFrameworks extends AppCommand {
+
+    /**
+     * The application context.
+     */
+    public readonly context: ApplicationStore;
+
+
+    /**
+     * Deregisters and deletes all Frameworks stored in the application's
+     * Framework Bank.
+     * @param context
+     *  The application context.
+     */
+    constructor(context: ApplicationStore) {
+        super();
+        this.context = context;
+    }
+
+
+    /**
+     * Executes the command.
+     */
+    public async execute(): Promise<void> {
+        // Create raw references
+        const fileAuthority = toRaw(this.context.fileAuthority);
+        const frameworkBank = this.context.frameworkBank;
+        const { sourceFramework, sourceVersion } = this.context.activeEditor.file;
+        const { targetFramework, targetVersion } = this.context.activeEditor.file;
+        // Deregister frameworks
+        let reloadFile = false;
+        for(const [fileId, file] of this.context.frameworkBank.files) {
+            const { id, version } = JSON.parse(file.name);
+            // Determine if file reload is necessary
+            reloadFile ||=
+                (id === sourceFramework && version === sourceVersion) ||
+                (id === targetFramework && version === targetVersion);
+            // Remove framework from registry
+            fileAuthority.registry.deregisterFramework(id, version);
+            // Delete framework from framework bank
+            frameworkBank.deleteFile(fileId);
+        }
+        // Reload open file
+        if(reloadFile) {
+            const file = toRaw(this.context.activeEditor.file) as MappingFile;
+            const reloadedFile = await fileAuthority.reloadMappingFile(file);
+            new LoadFile(this.context, reloadedFile).execute();
+        }
+    }
+
+}

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/ApplicationSettings/index.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/ApplicationSettings/index.ts
@@ -1,8 +1,9 @@
-import { FrameworkSourceFile, type Framework } from "@/assets/scripts/MappingFileAuthority";
 import { Browser } from "@/assets/scripts/Utilities";
 import { AppCommand } from "../AppCommand";
 import { LoadSettings } from "./LoadSettings";
-import { RegisterFramework } from "./RegisterFramework";
+import { LoadFrameworkFile } from "./LoadFramework";
+import { UnloadStoredFrameworks } from "./UnloadStoredFrameworks";
+import type { Framework } from "@/assets/scripts/MappingFileAuthority";
 import type { AppSettings } from "@/assets/scripts/Application";
 import type { ApplicationStore } from "@/stores/ApplicationStore";
 
@@ -20,7 +21,7 @@ export function loadSettings(context: ApplicationStore, settings: AppSettings): 
 }
 
 /**
- * Registers an existing framework with the application.
+ * Registers and saves a framework to the application's Framework Bank.
  * @param context
  *  The application's context.
  * @param file
@@ -31,10 +32,8 @@ export function loadSettings(context: ApplicationStore, settings: AppSettings): 
 export async function registerExistingFramework(context: ApplicationStore, file: string): Promise<AppCommand> {
    // Deserialize framework file
    const json = JSON.parse(file) as Framework;
-   // Load framework into file source
-   const source = new FrameworkSourceFile(json);
    // Return command
-   return new RegisterFramework(context, source);
+   return new LoadFrameworkFile(context, json);
 }
 
 /**
@@ -60,4 +59,16 @@ export async function registerFrameworkFromFileSystem(context: ApplicationStore)
  */
 export async function registerFrameworkFromUrl(context: ApplicationStore, url: string): Promise<AppCommand> {
    return registerExistingFramework(context, await (await fetch(url)).text());
+}
+
+/**
+ * Deregisters and deletes all Frameworks stored in the application's
+ * Framework Bank.
+ * @param context
+ *  The application context.
+ * @returns
+ *  A command that represents the action.
+ */
+export async function unloadStoredFrameworks(context: ApplicationStore) {
+   return new UnloadStoredFrameworks(context);
 }

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/ApplicationSettings/index.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/ApplicationSettings/index.ts
@@ -1,5 +1,8 @@
+import { FrameworkSourceFile, type Framework } from "@/assets/scripts/MappingFileAuthority";
+import { Browser } from "@/assets/scripts/Utilities";
 import { AppCommand } from "../AppCommand";
 import { LoadSettings } from "./LoadSettings";
+import { RegisterFramework } from "./RegisterFramework";
 import type { AppSettings } from "@/assets/scripts/Application";
 import type { ApplicationStore } from "@/stores/ApplicationStore";
 
@@ -13,5 +16,48 @@ import type { ApplicationStore } from "@/stores/ApplicationStore";
  *  A command that represents the action.
  */
 export function loadSettings(context: ApplicationStore, settings: AppSettings): AppCommand {
-   return new LoadSettings(context, settings); 
+   return new LoadSettings(context, settings);
+}
+
+/**
+ * Registers an existing framework with the application.
+ * @param context
+ *  The application's context.
+ * @param file
+ *  The framework file.
+ * @returns
+ *  A command that represents the action.
+ */
+export async function registerExistingFramework(context: ApplicationStore, file: string): Promise<AppCommand> {
+   // Deserialize framework file
+   const json = JSON.parse(file) as Framework;
+   // Load framework into file source
+   const source = new FrameworkSourceFile(json);
+   // Return command
+   return new RegisterFramework(context, source);
+}
+
+/**
+ * Registers an existing framework, from the file system, with the application.
+ * @param context
+ *  The application's context.
+ * @returns
+ *  A command that represents the action.
+ */
+export async function registerFrameworkFromFileSystem(context: ApplicationStore): Promise<AppCommand> {
+   const { contents } = await Browser.openTextFileDialog(["json"], false);
+   return registerExistingFramework(context, contents as string);
+}
+
+/**
+ * Registers an existing framework, from a remote url, with the application.
+ * @param context
+ *  The application's context.
+ * @param url
+ *  The remote url.
+ * @returns
+ *  A command that represents the action.
+ */
+export async function registerFrameworkFromUrl(context: ApplicationStore, url: string): Promise<AppCommand> {
+   return registerExistingFramework(context, await (await fetch(url)).text());
 }

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/FileManagement/ClearFileRecoveryBank.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/FileManagement/ClearFileRecoveryBank.ts
@@ -29,7 +29,7 @@ export class ClearFileRecoveryBank extends AppCommand {
             if(id === this.context.activeEditor.id) {
                 continue;
             }
-            this.context.fileRecoveryBank.withdrawFile(id);
+            this.context.fileRecoveryBank.deleteFile(id);
         }
     }
 

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/FileManagement/RemoveFileFromRecoveryBank.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/FileManagement/RemoveFileFromRecoveryBank.ts
@@ -36,7 +36,7 @@ export class RemoveFileFromRecoveryBank extends AppCommand {
         // Cancel any outstanding saves
         this.editor.tryCancelAutosave();
         // Remove file from recovery bank
-        this.context.fileRecoveryBank.withdrawFile(this.editor.id);
+        this.context.fileRecoveryBank.deleteFile(this.editor.id);
     }
 
 }

--- a/src/mappings_editor/src/assets/scripts/Application/Commands/FileManagement/SaveFileToRecoveryBank.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Commands/FileManagement/SaveFileToRecoveryBank.ts
@@ -44,7 +44,7 @@ export class SaveFileToRecoveryBank extends AppCommand {
         // Serialize file
         const contents = fileSerializer.serialize(file);
         // Store file
-        this.context.fileRecoveryBank.storeOrUpdateFile(
+        this.context.fileRecoveryBank.saveFile(
             this.editor.id,
             this.editor.name,
             contents

--- a/src/mappings_editor/src/assets/scripts/Application/Configuration/AppSettings.ts
+++ b/src/mappings_editor/src/assets/scripts/Application/Configuration/AppSettings.ts
@@ -3,10 +3,11 @@
  */
 export const BaseAppSettings: AppSettings = {
     hotkeys: {
-        file: { 
+        file: {
             new_file: "",
             open_file: "",
             import_file: "",
+            register_framework: "",
             save_file: ""
         },
         edit: {
@@ -45,8 +46,9 @@ export type AppSettings = {
  */
 export type FileHotkeys = {
     new_file: string,
-    open_file: string, 
+    open_file: string,
     import_file: string,
+    register_framework: string,
     save_file: string
 }
 

--- a/src/mappings_editor/src/assets/scripts/MappingFile/Property/FrameworkObjectProperty/EditableDynamicFrameworkListing.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFile/Property/FrameworkObjectProperty/EditableDynamicFrameworkListing.ts
@@ -41,6 +41,13 @@ export class EditableDynamicFrameworkListing extends FrameworkListing {
     }
 
     /**
+     * The framework listing's current coverage.
+     */
+    public get coverage(): number {
+        return this._references.size / this._options.size;
+    }
+
+    /**
      * The framework listing's object id length.
      */
     public get objectIdLength(): number {
@@ -99,7 +106,7 @@ export class EditableDynamicFrameworkListing extends FrameworkListing {
         if(nextId === prevId) {
             return nextId;
         }
-        // If next object doesn't exists... 
+        // If next object doesn't exists...
         if(!this._options.has(nextId)) {
             // ...define the object
             let objectText = null;
@@ -117,7 +124,7 @@ export class EditableDynamicFrameworkListing extends FrameworkListing {
 
         // Increment the object's reference count
         this._references.set(nextId, this._references.get(nextId)! + 1);
-        
+
         // If previous object id exists...
         if(this._options.has(prevId)) {
             // ...decrement its reference count
@@ -134,11 +141,11 @@ export class EditableDynamicFrameworkListing extends FrameworkListing {
                 );
             }
         }
-        
+
         // Return the listing id
         return nextId;
     }
-    
+
     /**
      * Sets a framework object's text.
      * @param id
@@ -174,7 +181,7 @@ export class EditableDynamicFrameworkListing extends FrameworkListing {
             throw new Error(`Framework object '${ id }' does not exist.`)
         }
     }
-    
+
     /**
      * Returns the number of times a framework object's id is referenced.
      * @param id

--- a/src/mappings_editor/src/assets/scripts/MappingFile/Property/FrameworkObjectProperty/EditableStrictFrameworkListing.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFile/Property/FrameworkObjectProperty/EditableStrictFrameworkListing.ts
@@ -19,10 +19,22 @@ export class EditableStrictFrameworkListing extends FrameworkListing {
     private _idLength: number;
 
     /**
+     * The framework listing reference count.
+     */
+    private readonly _references: Map<string | null, number>;
+
+    /**
      * The framework listing.
      */
     public get options(): ReadonlyMap<string | null, string | null> {
         return this._options;
+    }
+
+    /**
+     * The framework listing's current coverage.
+     */
+    public get coverage(): number {
+        return this._references.size / (this._options.size - 1);
     }
 
     /**
@@ -44,8 +56,39 @@ export class EditableStrictFrameworkListing extends FrameworkListing {
         super(framework, version);
         this._options = new Map([[null, null]]);
         this._idLength = FrameworkListing.DEFAULT_OBJ_ID_LEN;
+        this._references = new Map();
     }
 
+    /**
+     * Pivots a framework object reference.
+     * @param nextId
+     *  The object's new id.
+     *  (`null` if it should not have a next id.)
+     * @param prevId
+     *  The object's previous id.
+     *  (`null` if it did not have a previous id.)
+     */
+    public pivotReference(nextId: string | null, prevId: string | null) {
+        if(nextId === prevId) {
+            return;
+        }
+        const prev = this._references.get(prevId);
+        if(prev !== undefined) {
+            if(prev === 1) {
+                this._references.delete(prevId);
+            } else {
+                this._references.set(prevId, prev - 1);
+            }
+        }
+        if(nextId !== null) {
+            const next = this._references.get(nextId);
+            if(next === undefined) {
+                this._references.set(nextId, 1);
+            } else {
+                this._references.set(nextId, next + 1);
+            }
+        }
+    }
 
     /**
      * Registers a framework object.
@@ -62,5 +105,5 @@ export class EditableStrictFrameworkListing extends FrameworkListing {
             throw new Error(`Framework Object '${ id }' already registered.`);
         }
     }
-    
+
 }

--- a/src/mappings_editor/src/assets/scripts/MappingFile/Property/FrameworkObjectProperty/FrameworkListing.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFile/Property/FrameworkObjectProperty/FrameworkListing.ts
@@ -22,6 +22,11 @@ export abstract class FrameworkListing {
     abstract get options(): ReadonlyMap<string | null, string | null>;
 
     /**
+     * The framework listing's current coverage.
+     */
+    abstract get coverage(): number;
+
+    /**
      * The framework listing's object id length.
      */
     abstract get objectIdLength(): number;

--- a/src/mappings_editor/src/assets/scripts/MappingFileAuthority/FrameworkRegistry/FrameworkRegistry.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileAuthority/FrameworkRegistry/FrameworkRegistry.ts
@@ -8,7 +8,7 @@ export class FrameworkRegistry {
      */
     private _registry: Map<string, Map<string, FrameworkSource>>
 
-    
+
     /**
      * Creates a new {@link MappingFrameworkRegistry}.
      */
@@ -29,17 +29,41 @@ export class FrameworkRegistry {
         }
         const framework = this._registry.get(source.id)!;
         // Select framework version
-        if(!framework.has(source.version)) {
-            framework.set(source.version, source);
-        } else {
-            throw new Error(
-                `Framework '${ 
-                    source.id
-                }@${
-                    source.version
-                }' already registered.`
-            );
+        framework.set(source.version, source);
+    }
+
+    /**
+     * Deregisters a framework from the registry, if it exists.
+     * @param id
+     *  The framework's identifier.
+     * @param version
+     *  The framework's version.
+     * @returns
+     *  True if the framework was removed, false otherwise.
+     */
+    public deregisterFramework(id: string, version: string): boolean {
+        const versions = this._registry.get(id);
+        if(versions && versions.has(version)) {
+            versions.delete(version);
+            if(!versions.size) {
+                this._registry.delete(id);
+            }
+            return true;
         }
+        return false;
+    }
+
+    /**
+     * Deregisters all frameworks from the registry, if any exist.
+     * @returns
+     *  True if frameworks were deregistered, false otherwise.
+     */
+    public deregisterAllFrameworks(): boolean {
+        if(this._registry.size) {
+            this._registry.clear();
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/mappings_editor/src/assets/scripts/Utilities/FileStore.ts
+++ b/src/mappings_editor/src/assets/scripts/Utilities/FileStore.ts
@@ -1,30 +1,32 @@
-export class FileRecoveryBank {
+export class FileStore {
 
     /**
-     * The recovery bank's local storage prefix.
+     * The file store's local storage prefix.
      */
-    private static PREFIX = "file_recovery_bank."
-
+    public readonly prefix: string;
 
     /**
-     * The recovered file list.
+     * The file store's list of files.
      */
     public files: Map<string, { name: string, date: Date, contents: string }>;
 
 
     /**
-     * Creates a {@link FileRecoveryBank}.
+     * Creates a {@link FileStore}.
+     * @param prefix
+     *  The file store's local storage prefix.
      */
-    constructor() {
+    constructor(prefix: string) {
+        this.prefix = prefix;
         this.files = new Map();
         for(let i = 0; i < localStorage.length; i++) {
             // Look up key
             const key = localStorage.key(i)!;
-            if(!key.startsWith(FileRecoveryBank.PREFIX)) {
+            if(!key.startsWith(this.prefix)) {
                 continue;
             }
             // Parse id
-            const id = key.substring(FileRecoveryBank.PREFIX.length);
+            const id = key.substring(this.prefix.length);
             const value = JSON.parse(localStorage.getItem(key)!);
             // Parse value
             value.date = new Date(value.date)
@@ -35,7 +37,10 @@ export class FileRecoveryBank {
 
 
     /**
-     * Stores or updates a file in the bank.
+     * Saves a file to the store.
+     * @remarks
+     *  If `id` matches an existing file in the store, that file will be
+     *  replaced by the provided file.
      * @param id
      *  The file's id.
      * @param name
@@ -43,8 +48,8 @@ export class FileRecoveryBank {
      * @param contents
      *  The file's contents.
      */
-    public storeOrUpdateFile(id: string, name: string, contents: string) {
-        const key = `${ FileRecoveryBank.PREFIX }${ id }`;
+    public saveFile(id: string, name: string, contents: string) {
+        const key = `${ this.prefix }${ id }`;
         const value = {
             name     : name,
             date     : new Date(),
@@ -59,12 +64,12 @@ export class FileRecoveryBank {
     }
 
     /**
-     * Withdraws a file from the bank.
+     * Deletes a file from the store.
      * @param id
-     *  The id of the file to withdraw.
+     *  The id of the file to delete.
      */
-    public withdrawFile(id: string) {
-        const key = `${ FileRecoveryBank.PREFIX }${ id }`;
+    public deleteFile(id: string) {
+        const key = `${ this.prefix }${ id }`;
         if(localStorage.getItem(key) !== null) {
             // Withdraw file
             this.files.delete(id);
@@ -74,7 +79,7 @@ export class FileRecoveryBank {
     }
 
     /**
-     * Sorts the file editor bank in reverse chronological order.
+     * Sorts the files in reverse chronological order.
      */
     private sortStore() {
         this.files = new Map(

--- a/src/mappings_editor/src/assets/scripts/Utilities/RawFocusBox/RawFocusBox.ts
+++ b/src/mappings_editor/src/assets/scripts/Utilities/RawFocusBox/RawFocusBox.ts
@@ -68,7 +68,8 @@ export class RawFocusBox {
             emitFocusIn: () => {},
             focusOut: this.onFocusOut.bind(this),
             emitFocusOut: () => {},
-            pointerdown: this.onPointerEvent.bind(this)
+            pointerdown: this.onPointerEvent.bind(this),
+            targetUpdate: this.onTargetUpdate.bind(this)
         }
         this._lastTarget = null;
     }
@@ -113,6 +114,7 @@ export class RawFocusBox {
         this._el.addEventListener("focusin", this._eventHandlers.focusIn);
         this._el.addEventListener("focusout", this._eventHandlers.focusOut);
         if(this._pointerEvent) {
+            this._el.addEventListener("pointerdown", this._eventHandlers.targetUpdate);
             this._el.addEventListener(this._pointerEvent, this._eventHandlers.pointerdown);
         }
         this._eventHandlers.emitFocusIn = focusIn;
@@ -125,6 +127,7 @@ export class RawFocusBox {
         this._el?.removeEventListener("focusin", this._eventHandlers.focusIn);
         this._el?.removeEventListener("focusout", this._eventHandlers.focusOut);
         if(this._pointerEvent) {
+            this._el?.removeEventListener("pointerdown", this._eventHandlers.targetUpdate);
             this._el?.removeEventListener(this._pointerEvent, this.onPointerEvent);
         }
     }
@@ -139,8 +142,12 @@ export class RawFocusBox {
      * Focus in behavior.
      */
     private onFocusIn() {
+        // If target currently focused, do nothing
+        if(this._focused) {
+            return;
+        }
         // If last target was inside an element with an exit flag...
-        if(this.isTargetInExitElement(this._lastTarget)) {
+        else if(this.isTargetInExitElement(this._lastTarget)) {
             // ...force container out of focus
             this._el!.blur();
         }
@@ -167,12 +174,20 @@ export class RawFocusBox {
     }
 
     /**
+     * Target update behavior.
+     * @param event
+     *  The pointer event.
+     */
+    private onTargetUpdate(event: PointerEvent) {
+        this._lastTarget = event.target as HTMLElement;
+    }
+
+    /**
      * Pointer event behavior.
      * @param event
      *  The pointer event.
      */
-    private onPointerEvent(event: PointerEvent | MouseEvent) {
-        this._lastTarget = event.target as HTMLElement;
+    private onPointerEvent() {
         // If target is inside an element with an exit flag...
         if(this.isTargetInExitElement(this._lastTarget)) {
             // ...emit unfocus...
@@ -233,6 +248,14 @@ type FocusEventHandlers = {
      * @param event
      *  The pointer event.
      */
-    pointerdown: (event: PointerEvent | MouseEvent) => void
+    pointerdown: (event: PointerEvent | MouseEvent) => void;
+
+    /**
+     * Target update handler.
+     * @param event
+     *  The pointer event.
+     */
+    targetUpdate: (event: PointerEvent) => void;
+
 
 }

--- a/src/mappings_editor/src/assets/scripts/Utilities/index.ts
+++ b/src/mappings_editor/src/assets/scripts/Utilities/index.ts
@@ -3,6 +3,6 @@ export * from "./Crypto";
 export * from "./HotkeyObserver";
 export * from "./Math";
 export * from "./PointerTracker";
-export * from "./FileRecoveryBank";
+export * from "./FileStore";
 export * from "./RawScrollBox";
 export * from "./RawFocusBox";

--- a/src/mappings_editor/src/components/Elements/AppFooterBar.vue
+++ b/src/mappings_editor/src/components/Elements/AppFooterBar.vue
@@ -25,10 +25,12 @@
       <div class="metric source-framework">
         <span class="framework">{{ sourceFramework }}:</span>
         <span class="version">{{ sourceVersion }}</span>
+        <span class="coverage">[{{ sourceCoverage }}]</span>
       </div>
       <div class="metric target-framework">
         <span class="framework">{{ targetFramework }}:</span>
         <span class="version">{{ targetVersion }}</span>
+        <span class="coverage">[{{ targetCoverage }}]</span>
       </div>
       <div class="metric mapping-validity valid" v-if="invalidMappingsCount === 0">
         <span class="icon">✓</span>All Mappings Valid
@@ -39,7 +41,7 @@
     </div>
   </div>
 </template>
-    
+
 <script lang="ts">
 // Dependencies
 import { defineComponent } from "vue";
@@ -65,7 +67,8 @@ export default defineComponent({
      *  The number of mappings in the active file.
      */
     mappingCount(): number {
-      return this.application.activeEditor.file.mappingObjects.size;
+      const size = this.application.activeEditor.file.mappingObjects.size;
+      return this.watchClosely(size);
     },
 
     /**
@@ -131,6 +134,16 @@ export default defineComponent({
     },
 
     /**
+     * Returns the active file's source framework coverage.
+     * @returns
+     *  The active file's source framework coverage.
+     */
+     sourceCoverage(): string {
+      const src = this.application.activeEditor.file.sourceFrameworkListing;
+      return this.watchClosely(`${ Math.round(src.coverage * 100) }%`);
+    },
+
+    /**
      * Returns the active file's target framework.
      * @returns
      *  The active file's target framework.
@@ -149,12 +162,23 @@ export default defineComponent({
     },
 
     /**
+     * Returns the active file's target framework coverage.
+     * @returns
+     *  The active file's target framework coverage.
+     */
+    targetCoverage(): string {
+      const tar = this.application.activeEditor.file.targetFrameworkListing;
+      return this.watchClosely(`${ Math.round(tar.coverage * 100) }%`);
+    },
+
+    /**
      * Returns the number of invalid mapping objects in the active view.
      * @returns
      *  The number of invalid mappings object in the active view.
      */
     invalidMappingsCount(): number {
-      return this.application.activeEditor.invalidObjects.size;
+      const size = this.application.activeEditor.invalidObjects.size;
+      return this.watchClosely(size);
     },
 
     /**
@@ -178,6 +202,18 @@ export default defineComponent({
      */
     normalize(str: string) {
       return str.replace(/_/g, " ").toLocaleUpperCase();
+    },
+
+    /**
+     * Returns the provided parameter.
+     * @remarks
+     *  The use of `toRaw()` in performance-critical operations prevents Vue
+     *  from consistently tracking changes to all properties. Tying the result
+     *  of this function to the current execution cycle ensures the provided
+     *  parameter is updated anytime the application executes a command.
+     */
+    watchClosely<T>(o: T): T {
+      return this.application.executionCycle ? o : o;
     }
 
   },
@@ -197,7 +233,7 @@ export default defineComponent({
   components: { FloppyDisk }
 });
 </script>
-    
+
 <style scoped>
 
 /** === Main Element === */
@@ -285,6 +321,10 @@ export default defineComponent({
 .version {
   margin-left: 4px;
   font-weight: 700;
+}
+
+.coverage {
+  margin-left: 4px;
 }
 
 /** === Validity Metrics === */

--- a/src/mappings_editor/src/stores/ApplicationStore.ts
+++ b/src/mappings_editor/src/stores/ApplicationStore.ts
@@ -76,6 +76,9 @@ export const useApplicationStore = defineStore('applicationStore', {
          *  The application command.
          */
         async execute(command: AppCommand | EditorCommand) {
+            // Update execution cycle
+            this.executionCycle++;
+            // Execute command
             if(command instanceof EditorCommand) {
                 // Execute editor command
                 await this.activeEditor.execute(command);

--- a/src/mappings_editor/src/stores/ContextMenuStore.ts
+++ b/src/mappings_editor/src/stores/ContextMenuStore.ts
@@ -76,10 +76,16 @@ export const useContextMenuStore = defineStore('contextMenuStore', {
                 id: "register_framework_options",
                 items: [
                     {
-                        text: `Register Framework...`,
+                        text: "Register Framework...",
                         type: MenuType.Item,
                         data: () => AppCommands.registerFrameworkFromFileSystem(app),
                         shortcut: file.register_framework
+                    },
+                    {
+                       text: "Unload All Frameworks",
+                       type: MenuType.Item,
+                       data: () => AppCommands.unloadStoredFrameworks(app),
+                       disabled: 0 === app.frameworkBank.files.size
                     }
                 ],
             }

--- a/src/mappings_editor/src/stores/ContextMenuStore.ts
+++ b/src/mappings_editor/src/stores/ContextMenuStore.ts
@@ -27,6 +27,7 @@ export const useContextMenuStore = defineStore('contextMenuStore', {
             const sections: ContextMenuSection[] = [
                 this.openFileMenu,
                 this.isRecoverFileMenuShown ? this.recoverFileMenu : null,
+                this.registerFrameworkMenu,
                 this.exportFileMenu,
                 this.saveFileMenu
             ].filter(Boolean) as ContextMenuSection[];
@@ -62,7 +63,28 @@ export const useContextMenuStore = defineStore('contextMenuStore', {
                 ],
             }
         },
-        
+
+        /**
+         * Returns the 'register framework' menu section.
+         * @returns
+         *  The 'register framework' menu section.
+         */
+        registerFrameworkMenu(): ContextMenuSection {
+            const app = useApplicationStore();
+            const file = app.settings.hotkeys.file;
+            return {
+                id: "register_framework_options",
+                items: [
+                    {
+                        text: `Register Framework...`,
+                        type: MenuType.Item,
+                        data: () => AppCommands.registerFrameworkFromFileSystem(app),
+                        shortcut: file.register_framework
+                    }
+                ],
+            }
+        },
+
         /**
          * Returns the 'export file' menu section.
          * @returns
@@ -78,7 +100,7 @@ export const useContextMenuStore = defineStore('contextMenuStore', {
             const canExportNavigatorLayer = navigatorSupport.has(editor.file.targetFramework);
 
             // Build options
-            const exportAsOptions: ContextMenuSection = { 
+            const exportAsOptions: ContextMenuSection = {
                 id: "export_as_options",
                 items: [
                     {
@@ -109,7 +131,7 @@ export const useContextMenuStore = defineStore('contextMenuStore', {
             }
 
             // Return menu
-            return { 
+            return {
                 id: "export_as",
                 items: [ {
                     text: "Export As",
@@ -128,7 +150,7 @@ export const useContextMenuStore = defineStore('contextMenuStore', {
         recoverFileMenu(): ContextMenuSection {
             const app = useApplicationStore();
             const files = app.fileRecoveryBank.files;
-            
+
             // Build file list
             const items: ContextMenu[] = [];
             for(const [id, { name, date, contents }] of files) {
@@ -157,7 +179,7 @@ export const useContextMenuStore = defineStore('contextMenuStore', {
                 text: "Open Recovered Files",
                 type: MenuType.Submenu,
                 sections: [
-                    { 
+                    {
                         id: "recovered_files",
                         items
                     },
@@ -173,7 +195,7 @@ export const useContextMenuStore = defineStore('contextMenuStore', {
             }
 
             // Return menu
-            return { 
+            return {
                 id: "recover_file_options",
                 items: [ submenu ]
             };
@@ -215,7 +237,7 @@ export const useContextMenuStore = defineStore('contextMenuStore', {
             return (ids.length === 1 && ids[0] !== editor.id) || 1 < ids.length;
         },
 
-        
+
         ///////////////////////////////////////////////////////////////////////
         //  2. Edit Menus  ////////////////////////////////////////////////////
         ///////////////////////////////////////////////////////////////////////
@@ -357,7 +379,7 @@ export const useContextMenuStore = defineStore('contextMenuStore', {
             }
         },
 
-        
+
         ///////////////////////////////////////////////////////////////////////
         //  3. View Menus  ////////////////////////////////////////////////////
         ///////////////////////////////////////////////////////////////////////
@@ -430,7 +452,7 @@ export const useContextMenuStore = defineStore('contextMenuStore', {
             };
         },
 
-        
+
         ///////////////////////////////////////////////////////////////////////
         //  4. Help Menu  /////////////////////////////////////////////////////
         ///////////////////////////////////////////////////////////////////////
@@ -455,7 +477,7 @@ export const useContextMenuStore = defineStore('contextMenuStore', {
                 type: MenuType.Submenu,
                 sections: [
                     { id: "help_links", items },
-                    { 
+                    {
                         id: "version",
                         items: [
                             {

--- a/src/mappings_editor/src/stores/HotkeyStore.ts
+++ b/src/mappings_editor/src/stores/HotkeyStore.ts
@@ -61,6 +61,11 @@ export const useHotkeyStore = defineStore('hotkeyStore', {
                     disabled: editor.id === MappingFileEditor.Phantom.id
                 },
                 {
+                    data: () => AppCommands.registerFrameworkFromFileSystem(app),
+                    shortcut: file.register_framework,
+                    repeatable: false
+                },
+                {
                     data: () => AppCommands.saveActiveFileToDevice(app),
                     shortcut: file.save_file,
                     repeatable: false,


### PR DESCRIPTION
Fixes #209

## What Changed
This PR allows users to add custom frameworks to the editor.

## How to Use

### 1. Create a Framework File:

Create and save a Framework File: 

```json
{
    "frameworkId": "contoso_product_list",
    "frameworkVersion": "14.5",
    "categories": {
        "point-of-sales-products": [
            {
                "id": "PRD-01",
                "name": "Contoso Sales Plus",
                "description": "An software interface that processes and records payments."
            },
            {
                "id": "PRD-02",
                "name": "Contoso Sales Plus - Software Agent",
                "description": "A software agent the interfaces with the payment gateway."
            }
        ],
        "business-management-products": [
            {
                "id": "PRD-03",
                "name": "Contoso Business Management Suite",
                "description": "A suite of tools to manage your business."
            }
        ],
        "accounting-products": [
            {
                "id": "PRD-04",
                "name": "Contoso Money for Business",
                "description": "An accounting software for enterprise."
            }
        ]
    }
}
```

### 2. Register your Framework

Go to `File` > `Register Framework...` and select the Framework File you wish to register:

<img width="331" alt="image" src="https://github.com/user-attachments/assets/1cdcacd9-217b-448e-804e-50324724be5c">

### 3. Use

Any Mapping File that references your framework:

<img width="458" alt="image" src="https://github.com/user-attachments/assets/65c00a08-5409-4950-89ea-2b2e5b77d0b2">

Will have its selection limited to the items listed in the Framework File:

<img width="1302" alt="image" src="https://github.com/user-attachments/assets/7df49990-6414-4b87-842c-15e229b1b53e">

If you've registered your framework with a pre-existing file, the Editor will highlight any inconsistencies it finds:

<img width="590" alt="image" src="https://github.com/user-attachments/assets/ea3a689b-1459-44d8-90ac-54a4626dfe29">

## Load a Framework File via URL

Framework Files can also be loaded automatically when the editor starts by specifying each Framework File's publicly-hosted URL using the `framework` query parameter. 

There is no limit on the number of Framework Files that can be registered.

```
https://.../mappings-editor/?framework=[URL #1]&framework=[URL #2]&framework=[URL #3]
```

## Unloading Framework Files

Go to `File` > `Unload All Frameworks` to remove all user-registered frameworks from the Editor. Unloading Framework files will not prevent you from opening a Mapping File that references it. If you open a Mapping File _without_ its associated Framework File, the Editor will simply default back to regular text fields, allowing you to enter any values you choose.

## Track Mapping Coverage

This PR also introduces _Mapping Coverage_. In the Editor's footer, you can now track how much of the source and target framework your Mapping File covers (by percent):

<img width="648" alt="image" src="https://github.com/user-attachments/assets/2504dfed-327d-445d-abdf-95884529321c">
