### PR TITLE
feat: add migration context and fix framework load

### DIFF
--- a/src/mappings_editor/src/assets/scripts/MappingFileAuthority/FrameworkRegistry/Framework/Framework.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileAuthority/FrameworkRegistry/Framework/Framework.ts
@@ -1,3 +1,4 @@
+import type { FrameworkCategories } from "./FrameworkCategories";
 import type { FrameworkObject } from "./FrameworkObject";
 
 export type Framework = {
@@ -16,4 +17,9 @@ export type Framework = {
      * The framework's set of framework objects.
      */
     frameworkObjects: FrameworkObject[];
+
+    /**
+     * The framework's objects organized by category.
+     */
+    categories: FrameworkCategories;
 }

--- a/src/mappings_editor/src/assets/scripts/MappingFileAuthority/FrameworkRegistry/Framework/FrameworkCategories.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileAuthority/FrameworkRegistry/Framework/FrameworkCategories.ts
@@ -1,0 +1,3 @@
+import type { FrameworkObject } from "./FrameworkObject";
+
+export type FrameworkCategories = { [key: string]: FrameworkObject[] }

--- a/src/mappings_editor/src/assets/scripts/MappingFileAuthority/FrameworkRegistry/Framework/FrameworkMigration.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileAuthority/FrameworkRegistry/Framework/FrameworkMigration.ts
@@ -1,0 +1,44 @@
+import type { FrameworkObject } from "./FrameworkObject";
+
+export type FrameworkMigration = {
+
+    /**
+     * The list of framework object additions.
+     */
+    added_framework_objects: FrameworkObject[];
+
+    /**
+     * The list of framework object removals.
+     */
+    removed_framework_objects: FrameworkObject[];
+
+    /**
+     * The internal map of changed framework object names.
+     */
+    changed_names: Map<string, [string, string]>;
+
+    /**
+     * The internal map of changed framework object descriptions.
+     */
+    changed_descriptions: Map<string, [string, string]>;
+
+    /**
+     * The internal map of added mitigations to framework objects.
+     */
+    added_mitigations: Map<string, FrameworkObject[]>;
+
+    /**
+     * The internal map of removed mitigations from framework objects.
+     */
+    removed_mitigations: Map<string, FrameworkObject[]>;
+
+    /**
+     * The internal map of added detections to framework objects.
+     */
+    added_detections: Map<string, FrameworkObject[]>;
+
+    /**
+     * The internal map of removed detections from framework objects.
+     */
+    removed_detections: Map<string, FrameworkObject[]>;
+}

--- a/src/mappings_editor/src/assets/scripts/MappingFileAuthority/FrameworkRegistry/Framework/index.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileAuthority/FrameworkRegistry/Framework/index.ts
@@ -1,3 +1,4 @@
 export * from "./Framework";
 export * from "./FrameworkObject";
 export * from "./FrameworkDiff";
+export * from "./FrameworkMigration";

--- a/src/mappings_editor/src/assets/scripts/MappingFileAuthority/FrameworkRegistry/FrameworkSource.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileAuthority/FrameworkRegistry/FrameworkSource.ts
@@ -1,4 +1,6 @@
 import type { Framework } from "./Framework/Framework";
+import type { FrameworkCategories } from "./Framework/FrameworkCategories";
+import type { FrameworkObject } from "./Framework/FrameworkObject";
 
 export abstract class FrameworkSource {
 
@@ -12,7 +14,7 @@ export abstract class FrameworkSource {
      */
     public readonly version: string;
 
-    
+
     /**
      * Creates a new {@link FrameworkSource}.
      * @param id
@@ -31,6 +33,20 @@ export abstract class FrameworkSource {
      * @returns
      *  A Promise that resolves with the framework.
      */
-    abstract getFramework(): Promise<Framework>  
+    abstract getFramework(): Promise<Framework>
+
+
+    /**
+     * Moves objects in FrameworkCategores to FrameworkObjects
+     */
+  public getFrameworkObjects(categories: FrameworkCategories): FrameworkObject[] {
+        let objects: FrameworkObject[] = [];
+        for (const category in categories) {
+            objects = [...objects, ...categories[category]]
+        }
+        const uniqueFrameworkObjects = new Set(objects);
+        objects = [...uniqueFrameworkObjects];
+        return objects;
+    }
 
 }

--- a/src/mappings_editor/src/assets/scripts/MappingFileAuthority/FrameworkRegistry/FrameworkSourceFile.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileAuthority/FrameworkRegistry/FrameworkSourceFile.ts
@@ -8,7 +8,7 @@ export class FrameworkSourceFile extends FrameworkSource {
      */
     private _file: Framework;
 
-    
+
     /**
      * Creates a {@link FrameworkSourceFile}.
      * @param file
@@ -26,6 +26,7 @@ export class FrameworkSourceFile extends FrameworkSource {
      *  A Promise that resolves with the framework.
      */
     override getFramework(): Promise<Framework> {
+        this._file.frameworkObjects = this.getFrameworkObjects(this._file.categories);
         return Promise.resolve<Framework>(this._file);
     }
 

--- a/src/mappings_editor/src/assets/scripts/MappingFileAuthority/FrameworkRegistry/FrameworkSourceUrl.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileAuthority/FrameworkRegistry/FrameworkSourceUrl.ts
@@ -13,7 +13,7 @@ export class FrameworksSourceUrl extends FrameworkSource {
      */
     private _file: Framework | undefined;
 
-    
+
     /**
      * Creates a {@link FrameworksSourceUrl}.
      * @param id
@@ -38,6 +38,7 @@ export class FrameworksSourceUrl extends FrameworkSource {
         if(this._file === undefined) {
             try {
                 this._file = await (await fetch(this._url)).json() as Framework;
+                this._file.frameworkObjects = this.getFrameworkObjects(this._file.categories);
             } catch(err) {
                 throw new Error(`Failed to download framework '${ this._url }'.`);
             }

--- a/src/mappings_editor/src/assets/scripts/MappingFileAuthority/MigrationContext.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileAuthority/MigrationContext.ts
@@ -1,5 +1,108 @@
-import type { FrameworkDiff, FrameworkObject, FrameworkRegistry } from "./FrameworkRegistry";
+import type { MappingFile, MappingObject } from "../MappingFile";
+import { FrameworkComparator } from "./FrameworkComparator";
+import type { Framework, FrameworkDiff, FrameworkObject, FrameworkRegistry, FrameworkMigration} from "./FrameworkRegistry";
 
 export class MigrationContext {
+
+    /**
+     * Framework registry.
+     */
+    public readonly registry: FrameworkRegistry;
+
+    /**
+     * List of source frameworks.
+     */
+    public sourceFrameworks: Framework[];
+
+    /**
+     * A map of framework migrations by mapping file key.
+     */
+    public readonly migrationContext: Map<string, FrameworkMigration>;
+
+
+    /**
+     * Creates a new {@link MigrationContext}.
+     * @param registry
+     *  The framework comparator's framework registry.
+     */
+    constructor(registry: FrameworkRegistry) {
+        this.registry = registry;
+        this.sourceFrameworks = [];
+        this.migrationContext = new Map<string, FrameworkMigration>();
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////
+    //  1. Compile all framework migration differences  ///////////////////////
+    ///////////////////////////////////////////////////////////////////////////
+
+
+    /**
+     * Iterate through each source framework and compile target framework updates
+     * @param file
+     *  The mapping file to migrate
+     * @param targetFramework
+     *  The framework to migrate the mapping file to.
+     */
+    public async buildContext(file: MappingFile, targetFramework: Framework): Promise<void> {
+
+        // get all source frameworks from target objects in mapping file
+        const sourceFrameworks = await this.getSourceFrameworks(file);
+
+        // create a new migration context for this mapping file
+        const migration: FrameworkMigration = {
+            added_framework_objects: [],
+            removed_framework_objects: [],
+            changed_names: new Map<string, [string, string]>(),
+            changed_descriptions: new Map<string, [string, string]>(),
+            added_mitigations: new Map<string, FrameworkObject[]>(),
+            removed_mitigations: new Map<string, FrameworkObject[]>(),
+            added_detections: new Map<string, FrameworkObject[]>(),
+            removed_detections: new Map<string, FrameworkObject[]>(),
+        };
+
+        // iterate through each source framework and compile differences
+        sourceFrameworks.forEach((sourceFramework) => {
+            let fc: FrameworkComparator = new FrameworkComparator();
+            fc.compareFrameworks(sourceFramework, targetFramework);
+            migration.added_framework_objects = [...migration.added_framework_objects, ...fc.diff.added_framework_objects];
+            migration.removed_framework_objects = [...migration.removed_framework_objects, ...fc.diff.removed_framework_objects];
+            migration.changed_names = new Map<string, [string, string]>([...migration.changed_names.entries(), ...fc.diff.changed_names.entries()]);
+            migration.changed_descriptions = new Map<string, [string, string]>([...migration.changed_descriptions.entries(), ...fc.diff.changed_descriptions.entries()]);
+            migration.added_mitigations = new Map<string, FrameworkObject[]>([...migration.added_mitigations.entries(), ...fc.diff.added_mitigations.entries()]);
+            migration.removed_mitigations = new Map<string, FrameworkObject[]>([...migration.removed_mitigations.entries(), ...fc.diff.removed_mitigations.entries()]);
+            migration.added_detections = new Map<string, FrameworkObject[]>([...migration.added_detections.entries(), ...fc.diff.added_detections.entries()]);
+            migration.removed_detections = new Map<string, FrameworkObject[]>([...migration.removed_detections.entries(), ...fc.diff.removed_detections.entries()]);
+        });
+        this.migrationContext.set(file.id, migration);
+    }
+
+    /**
+     * Get unique set of source frameworks from all mappings in the mapping file
+     * @param file
+     * The mapping file to migrate
+     */
+    private async getSourceFrameworks(file: MappingFile): Promise<Framework[]> {
+
+        const frameworks: Framework[] = [];
+
+        // get all framework ids and framework versions in mapping objects
+        const frameworkValueMap: Map<string, string> = new Map<string, string>();
+        for (const mappingObject of file.mappingObjects.values()) {
+            frameworkValueMap.set(mappingObject.targetObject.objectFramework, mappingObject.targetObject.objectVersion);
+        }
+
+        // fetch unique frameworks in mapping objects
+        for (const [id, version] of frameworkValueMap.entries()) {
+            try {
+                const framework = await this.registry.getFramework(id, version);
+                frameworks.push(framework);
+            } catch {
+                continue;
+            }
+        }
+        return frameworks;
+    }
+
 
 }

--- a/src/mappings_editor/src/assets/scripts/MappingFileAuthority/MigrationContext.ts
+++ b/src/mappings_editor/src/assets/scripts/MappingFileAuthority/MigrationContext.ts
@@ -1,0 +1,5 @@
+import type { FrameworkDiff, FrameworkObject, FrameworkRegistry } from "./FrameworkRegistry";
+
+export class MigrationContext {
+
+}


### PR DESCRIPTION
# What Changed

- refactor framework comparator
- re-add framework categories type since this is part of the framework json schema
- parse framework objects field in framework from framework categories on load
- add migration context